### PR TITLE
Rsql license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,11 @@
     </dependency>
 
     <dependency>
+      <groupId>cz.jirutka.rsql</groupId>
+      <artifactId>rsql-parser</artifactId>
+      <version>2.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.tennaito</groupId>
       <artifactId>rsql-jpa</artifactId>
       <version>2.0.2</version>

--- a/src/main/java/org/jboss/license/dictionary/LicenseDbStore.java
+++ b/src/main/java/org/jboss/license/dictionary/LicenseDbStore.java
@@ -104,6 +104,7 @@ public class LicenseDbStore {
                 .withPredicateBuilder(new CustomizedPredicateBuilder())
                 .withPredicateBuilderStrategy(new CustomizedPredicateBuilderStrategy());
 
+        log.debugf("### About to parse rsql %s ...", rsql);
         Node rootNode = new RSQLParser().parse(rsql);
 
         Predicate predicate = rootNode.accept(visitor, entityManager);

--- a/src/main/java/org/jboss/license/dictionary/LicenseDbStore.java
+++ b/src/main/java/org/jboss/license/dictionary/LicenseDbStore.java
@@ -113,13 +113,27 @@ public class LicenseDbStore {
     }
 
     protected boolean isNonEmptyRsqlString(Optional<String> rsql) {
-        if (!rsql.isPresent() || "".equalsIgnoreCase(rsql.get())) {
+        if (!rsql.isPresent() || "".equalsIgnoreCase(rsql.get().trim())) {
             return false;
         }
         return true;
     }
 
     /* LICENSE */
+
+    public List<License> getAllLicense(Optional<String> rsqlSearch) {
+
+        if (isNonEmptyRsqlString(rsqlSearch)) {
+            log.debugf("Get all license by rsql %s ...", rsqlSearch.get());
+
+            CriteriaQuery<License> query = createCriteriaQuery(License.class, rsqlSearch.get());
+            query.distinct(true);
+            return entityManager.createQuery(query).getResultList();
+        }
+
+        log.debug("Get all license ...");
+        return entityManager.createNamedQuery(License.QUERY_FIND_ALL_UNORDERED, License.class).getResultList();
+    }
 
     public License saveLicense(License license) {
         log.debugf("Saving license: %s", license);
@@ -138,11 +152,6 @@ public class LicenseDbStore {
         return entityManager.find(License.class, id);
     }
 
-    public List<License> getAllLicense() {
-        log.debug("Get all license ...");
-        return entityManager.createNamedQuery(License.QUERY_FIND_ALL_UNORDERED, License.class).getResultList();
-    }
-
     public boolean deleteLicense(Integer id) {
         log.debugf("Deleting license: %d", id);
         License entity = entityManager.find(License.class, id);
@@ -154,7 +163,7 @@ public class LicenseDbStore {
     }
 
     public void replaceAllLicensesWith(Map<String, License> licenseEntityByAlias) {
-        getAllLicense().forEach(entityManager::remove);
+        getAllLicense(Optional.ofNullable(null)).forEach(entityManager::remove);
         licenseEntityByAlias.keySet().stream().forEach(aliasName -> {
 
             License license = licenseEntityByAlias.get(aliasName);

--- a/src/main/java/org/jboss/license/dictionary/LicenseStore.java
+++ b/src/main/java/org/jboss/license/dictionary/LicenseStore.java
@@ -19,16 +19,11 @@ package org.jboss.license.dictionary;
 
 import static org.jboss.license.dictionary.utils.Mappers.fullMapper;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -46,6 +41,7 @@ import org.jboss.license.dictionary.model.LicenseAlias;
 import org.jboss.license.dictionary.model.LicenseApprovalStatus;
 import org.jboss.license.dictionary.model.LicenseDeterminationType;
 import org.jboss.license.dictionary.model.LicenseHintType;
+import org.jboss.license.dictionary.utils.QueryUtils;
 import org.jboss.logging.Logger;
 
 /**
@@ -59,107 +55,81 @@ public class LicenseStore {
     @Inject
     private LicenseDbStore dbStore;
 
-    private Map<Integer, LicenseRest> licensesById;
+    /* LICENSE */
 
-    @Transactional
-    public synchronized void init() {
-        if (licensesById != null) {
-            log.warn("License Store was already initialized! skipping");
-            return;
-        } else {
-            log.warn("Started License Store initialization");
-            load();
-            log.info("Finished License Store initialization");
-        }
-    }
+    public List<LicenseRest> getAllLicense(Optional<String> rsqlSearch) {
 
-    @Transactional
-    public synchronized void forceReload() {
-        licensesById = null;
-        init();
-    }
-
-    @Transactional
-    public synchronized void load() {
-        licensesById = dbStore.getAllLicense().stream().map(entity -> fullMapper.map(entity, LicenseRest.class))
-                .peek(LicenseRest::checkIntegrity).collect(Collectors.toMap(l -> l.getId(), l -> l));
+        return dbStore.getAllLicense(rsqlSearch).stream().map(entity -> fullMapper.map(entity, LicenseRest.class))
+                .collect(Collectors.toList());
     }
 
     public Optional<LicenseRest> getLicenseById(Integer licenseId) {
-        return Optional.ofNullable(licensesById.get(licenseId));
+        log.infof("Get license by id %d", licenseId);
+
+        License license = dbStore.getLicenseById(licenseId);
+        if (license == null) {
+            return Optional.ofNullable(null);
+        }
+
+        return Optional.ofNullable(fullMapper.map(license, LicenseRest.class));
     }
 
     public Optional<LicenseRest> getLicenseForFedoraName(String name) {
-        return findSingle(l -> searchEquals(name, l.getFedoraName()));
+
+        String rsql = "fedoraName=='" + QueryUtils.escapeReservedChars(name) + "'";
+        List<LicenseRest> results = getAllLicense(Optional.of(rsql));
+        if (results == null || results.isEmpty()) {
+            return Optional.ofNullable(null);
+        } else {
+            return Optional.of(results.get(0));
+        }
     }
 
     public Optional<LicenseRest> getLicenseForSpdxName(String name) {
-        return findSingle(l -> searchEquals(name, l.getSpdxName()));
+
+        String rsql = "spdxName=='" + QueryUtils.escapeReservedChars(name) + "'";
+        List<LicenseRest> results = getAllLicense(Optional.of(rsql));
+        if (results == null || results.isEmpty()) {
+            return Optional.ofNullable(null);
+        } else {
+            return Optional.of(results.get(0));
+        }
     }
 
-    // public Optional<LicenseRest> getForUrl(String url) {
-    // return findSingle(l -> searchEquals(url, l.getUrl()));
-    // }
-    //
-    // public Optional<LicenseRest> getForTextUrl(String url) {
-    // return findSingle(l -> searchEquals(url, l.getTextUrl()));
-    // }
-
     public Optional<LicenseRest> getLicenseForNameAlias(String alias) {
-        return findSingle(l -> isOneOf(l.getAliasNames(), alias));
+
+        String rsql = "aliases.aliasName=='" + QueryUtils.escapeReservedChars(alias) + "'";
+        List<LicenseRest> results = getAllLicense(Optional.of(rsql));
+        if (results == null || results.isEmpty()) {
+            return Optional.ofNullable(null);
+        } else {
+            return Optional.of(results.get(0));
+        }
     }
 
     public Optional<LicenseRest> getLicenseForCode(String code) {
-        return findSingle(l -> searchEquals(code, l.getCode()));
+
+        String rsql = "code=='" + QueryUtils.escapeReservedChars(code) + "'";
+        List<LicenseRest> results = getAllLicense(Optional.of(rsql));
+        if (results == null || results.isEmpty()) {
+            return Optional.ofNullable(null);
+        } else {
+            return Optional.of(results.get(0));
+        }
     }
 
     public LicenseRest saveLicense(LicenseRest licenseRest) {
         License entity = fullMapper.map(licenseRest, License.class);
         entity = dbStore.saveLicense(entity);
 
-        licenseRest = fullMapper.map(entity, LicenseRest.class);
-        licensesById.put(entity.getId(), licenseRest);
-        return licenseRest;
+        return fullMapper.map(entity, LicenseRest.class);
     }
 
     public LicenseRest updateLicense(LicenseRest licenseRest) {
         License entity = fullMapper.map(licenseRest, License.class);
         entity = dbStore.updateLicense(entity);
 
-        licenseRest = fullMapper.map(entity, LicenseRest.class);
-        licensesById.put(entity.getId(), licenseRest);
-        return licenseRest;
-    }
-
-    public List<LicenseRest> getAllLicense() {
-        ArrayList<LicenseRest> result = new ArrayList<>(licensesById.values());
-        result.sort(Comparator.comparing(LicenseRest::getCode));
-        return result;
-    }
-
-    public Set<LicenseRest> findBySearchTerm(String denormalizedSearchTerm) {
-        final String searchTerm = denormalizedSearchTerm.toLowerCase();
-        Set<LicenseRest> resultSet = new TreeSet<>(Comparator.comparing(LicenseRest::getCode));
-
-        resultSet.addAll(join(getLicenseForFedoraName(searchTerm), getLicenseForSpdxName(searchTerm),
-                getLicenseForNameAlias(searchTerm), getLicenseForCode(searchTerm)));
-
-        licensesById.values().stream().filter(l -> l.toString().toLowerCase().contains(searchTerm)).forEach(resultSet::add);
-
-        return resultSet;
-    }
-
-    public Set<LicenseRest> findByExactSearchTerm(String denormalizedSearchTerm) {
-        final String searchTerm = denormalizedSearchTerm.toLowerCase();
-        Set<LicenseRest> resultSet = new TreeSet<>(Comparator.comparing(LicenseRest::getCode));
-
-        resultSet.addAll(join(getLicenseForFedoraName(searchTerm), getLicenseForSpdxName(searchTerm),
-                getLicenseForNameAlias(searchTerm), getLicenseForCode(searchTerm)));
-
-        licensesById.values().stream().filter(l -> l.toString().toLowerCase().equalsIgnoreCase(searchTerm))
-                .forEach(resultSet::add);
-
-        return resultSet;
+        return fullMapper.map(entity, LicenseRest.class);
     }
 
     <T> List<T> join(Optional<T>... optionals) {
@@ -168,9 +138,7 @@ public class LicenseStore {
 
     @Transactional
     public boolean deleteLicense(Integer licenseId) {
-        boolean result = dbStore.deleteLicense(licenseId);
-        licensesById.remove(licenseId);
-        return result;
+        return dbStore.deleteLicense(licenseId);
     }
 
     @Transactional
@@ -189,9 +157,6 @@ public class LicenseStore {
 
         log.infof("will replace existing entities with %d new entities", licenseEntityByAlias.values().size());
         dbStore.replaceAllLicensesWith(licenseEntityByAlias);
-        log.info("started loading imported entities");
-        load();
-        log.info("finished loading imported entities");
     }
 
     @Transactional
@@ -199,7 +164,10 @@ public class LicenseStore {
         log.info("started replacing licens aliases with import data.");
 
         licensesAliasByName.keySet().stream().forEach(key -> {
+
             Collection<LicenseAliasRest> licensesAliases = licensesAliasByName.get(key);
+            log.infof("analyzing licensesAliases %s", licensesAliases);
+
             Integer licenseId = licensesAliases.iterator().next().getLicenseId();
             License license = dbStore.getLicenseById(licenseId);
             if (license != null) {
@@ -216,10 +184,6 @@ public class LicenseStore {
                 log.infof("No license found for id: %d", licenseId);
             }
         });
-
-        log.info("started loading imported entities");
-        load();
-        log.info("finished loading imported entities");
     }
 
     /* LICENSE APPROVAL STATUS */
@@ -245,8 +209,7 @@ public class LicenseStore {
         LicenseApprovalStatus entity = fullMapper.map(licenseApprovalStatusRest, LicenseApprovalStatus.class);
         entity = dbStore.saveLicenseApprovalStatus(entity);
 
-        licenseApprovalStatusRest = fullMapper.map(entity, LicenseApprovalStatusRest.class);
-        return licenseApprovalStatusRest;
+        return fullMapper.map(entity, LicenseApprovalStatusRest.class);
     }
 
     /* LICENSE DETERMINATION TYPE */
@@ -273,8 +236,7 @@ public class LicenseStore {
         LicenseDeterminationType entity = fullMapper.map(licenseDeterminationTypeRest, LicenseDeterminationType.class);
         entity = dbStore.saveLicenseDeterminationType(entity);
 
-        licenseDeterminationTypeRest = fullMapper.map(entity, LicenseDeterminationTypeRest.class);
-        return licenseDeterminationTypeRest;
+        return fullMapper.map(entity, LicenseDeterminationTypeRest.class);
     }
 
     /* LICENSE HINT TYPE */
@@ -300,24 +262,7 @@ public class LicenseStore {
         LicenseHintType entity = fullMapper.map(licenseHintTypeRest, LicenseHintType.class);
         entity = dbStore.saveLicenseHintType(entity);
 
-        licenseHintTypeRest = fullMapper.map(entity, LicenseHintTypeRest.class);
-        return licenseHintTypeRest;
-    }
-
-    private Optional<LicenseRest> findSingle(Predicate<LicenseRest> predicate) {
-        return licensesById.values().stream().filter(predicate).findAny();
-    }
-
-    private boolean isOneOf(Collection<String> values, String value) {
-        if (value == null) {
-            return false;
-        }
-        String normalizedValue = value.toLowerCase();
-        return values.stream().anyMatch(v -> v.toLowerCase().equals(normalizedValue));
-    }
-
-    private boolean searchEquals(String value1, String value2) {
-        return value1 != null && value2 != null && value1.toLowerCase().equals(value2.toLowerCase());
+        return fullMapper.map(entity, LicenseHintTypeRest.class);
     }
 
 }

--- a/src/main/java/org/jboss/license/dictionary/api/LicenseRest.java
+++ b/src/main/java/org/jboss/license/dictionary/api/LicenseRest.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.jboss.license.dictionary.model.LicenseAlias;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -89,11 +87,8 @@ public class LicenseRest {
                 .map(alias -> alias.getAliasName()).collect(Collectors.toList());
     }
 
-    public void addAliases(Set<LicenseAlias> licenseAliases) {
-        licenseAliases.stream().forEach(licenseAlias -> {
-            aliases.add(LicenseAliasRest.Builder.newBuilder().id(licenseAlias.getId()).aliasName(licenseAlias.getAliasName())
-                    .licenseId(licenseAlias.getLicense().getId()).build());
-        });
+    public void addAlias(LicenseAliasRest licenseAliasesRest) {
+        aliases.add(licenseAliasesRest);
     }
 
     public void addAlias(Integer id, String licenseAlias, Integer licenseId) {

--- a/src/main/java/org/jboss/license/dictionary/endpoint/ExportEndpoint.java
+++ b/src/main/java/org/jboss/license/dictionary/endpoint/ExportEndpoint.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.MediaType;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * mstodo: Header
@@ -51,7 +52,7 @@ public class ExportEndpoint {
     public Map<String, JsonLicense> exportLicenses() {
         Map<String, JsonLicense> resultMap = new HashMap<>();
 
-        store.getAllLicense().forEach(license -> license.getAliasNames()
+        store.getAllLicense(Optional.ofNullable(null)).forEach(license -> license.getAliasNames()
                 .forEach(alias -> resultMap.put(alias, JsonLicense.fromLicenseRest(license))));
 
         return resultMap;

--- a/src/main/java/org/jboss/license/dictionary/endpoint/ImportEndpoint.java
+++ b/src/main/java/org/jboss/license/dictionary/endpoint/ImportEndpoint.java
@@ -40,7 +40,6 @@ import org.jboss.license.dictionary.api.LicenseRest;
 import org.jboss.license.dictionary.imports.JsonLicense;
 import org.jboss.license.dictionary.imports.JsonProjectLicense;
 import org.jboss.license.dictionary.utils.BadRequestException;
-import org.jboss.license.dictionary.utils.QueryUtils;
 import org.jboss.logging.Logger;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -102,28 +101,46 @@ public class ImportEndpoint {
     public void importLicenseAliases(Map<String, String[]> rhAlias) {
         log.debug("Import license aliases ...");
 
-        Map<String, Collection<LicenseAliasRest>> licensesAliasByName = new HashMap<String, Collection<LicenseAliasRest>>();
+        Map<LicenseRest, Collection<LicenseRest>> primaryVsSecondaryLicensesMap = new HashMap<LicenseRest, Collection<LicenseRest>>();
         rhAlias.forEach((alias, aliases) -> {
 
             try {
                 if (alias.startsWith("#")) {
-                    log.debugf("skipping a commented alias", alias);
+                    log.debugf("skipping the commented alias: %s", alias);
+                } else if (aliases == null || aliases.length == 0) {
+                    log.debugf("skipping empty list of secondary aliases for primary alias: %s", alias);
                 } else {
 
-                    LicenseRest licenseRest = pickLicenseByName(alias);
-                    log.infof("LicenseRest --> pickLicenseByName found %s for alias %s, aliases %s", licenseRest, alias,
-                            aliases);
+                    // Every license has been imported with an alias corresponding to its entry in the *url_rh_license.json file
+                    Optional<LicenseRest> maybeLicense = findLicenseByAlias(alias);
+                    if (maybeLicense.isPresent()) {
 
-                    List<LicenseAliasRest> licenseAliases = new ArrayList<LicenseAliasRest>();
-                    Arrays.stream(aliases).forEach(al -> {
-                        licenseAliases.add(
-                                LicenseAliasRest.Builder.newBuilder().licenseId(licenseRest.getId()).aliasName(al).build());
-                    });
+                        LicenseRest licenseRest = maybeLicense.get();
+                        List<LicenseRest> secondaryLicenses = new ArrayList<LicenseRest>();
 
-                    if (!licensesAliasByName.containsKey(alias)) {
-                        licensesAliasByName.put(alias, licenseAliases);
+                        log.infof("LicenseRest --> findLicenseByAlias found: %s for primary alias: %s", licenseRest, alias);
+
+                        Arrays.stream(aliases).forEach(secondaryAlias -> {
+                            Optional<LicenseRest> secondaryLicense = findLicenseByAlias(secondaryAlias);
+                            if (secondaryLicense.isPresent()) {
+                                // Secondary alias with an entry in *url_rh_license.json file
+                                secondaryLicenses.add(secondaryLicense.get());
+                            } else {
+                                log.infof("Secondary AliasName NOT FOUND!!! %s", secondaryAlias);
+                                // Secondary alias without an entry in *url_rh_license.json file (can be e.g. a SPDX
+                                // abbreviation)
+                                LicenseRest fakeSecondaryLicense = LicenseRest.Builder.newBuilder().build();
+                                fakeSecondaryLicense
+                                        .addAlias(LicenseAliasRest.Builder.newBuilder().aliasName(secondaryAlias).build());
+                                secondaryLicenses.add(fakeSecondaryLicense);
+                            }
+                        });
+
+                        if (!secondaryLicenses.isEmpty()) {
+                            primaryVsSecondaryLicensesMap.put(licenseRest, secondaryLicenses);
+                        }
                     } else {
-                        log.info("## multiple version of alias " + alias);
+                        log.infof("Primary AliasName NOT FOUND!!! %s", alias);
                     }
                 }
             } catch (NoSuchElementException exc) {
@@ -133,7 +150,7 @@ public class ImportEndpoint {
             }
         });
 
-        store.replaceAllLicenseAliasesWith(licensesAliasByName);
+        store.replaceAllLicenseAliasesWith(primaryVsSecondaryLicensesMap);
     }
 
     @ApiOperation(value = "Import the project icense json file", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
@@ -146,15 +163,28 @@ public class ImportEndpoint {
         projectLicenseStore.importProjectLicenses(jsonProjectLicenses);
     }
 
-    private LicenseRest pickLicenseByName(String alias) {
+    private Optional<LicenseRest> findLicenseByAlias(String alias) {
+        return store.getLicenseForNameAlias(alias);
+    }
 
-        alias = QueryUtils.escapeReservedChars(alias);
+    private Optional<LicenseRest> findLicenseByName(String alias) {
 
         // Look for Fedora Name
         Optional<LicenseRest> optionalLicenseRest = store.getLicenseForFedoraName(alias);
+
+        if (!optionalLicenseRest.isPresent()) {
+            // Look for Fedora abbreviation
+            optionalLicenseRest = store.getLicenseForFedoraAbbreviation(alias);
+        }
+
         if (!optionalLicenseRest.isPresent()) {
             // Look for SPDX Name
             optionalLicenseRest = store.getLicenseForSpdxName(alias);
+        }
+
+        if (!optionalLicenseRest.isPresent()) {
+            // Look for SPDX abbreviation
+            optionalLicenseRest = store.getLicenseForSpdxAbbreviation(alias);
         }
 
         // Look for aliasName (for licenses with empty Fedora and SPDX names)
@@ -162,12 +192,7 @@ public class ImportEndpoint {
             optionalLicenseRest = store.getLicenseForNameAlias(alias);
         }
 
-        if (!optionalLicenseRest.isPresent()) {
-            log.infof("AliasName NOT FOUND!!! %s", alias);
-            return null;
-        }
-
-        return optionalLicenseRest.get();
+        return optionalLicenseRest;
     }
 
     private void isSingleName(Map<String, Collection<LicenseRest>> licenseDataByName) {

--- a/src/main/java/org/jboss/license/dictionary/model/LicenseAlias.java
+++ b/src/main/java/org/jboss/license/dictionary/model/LicenseAlias.java
@@ -26,7 +26,6 @@ import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.GenericGenerator;
@@ -39,8 +38,7 @@ import lombok.ToString;
 
 @Entity(name = "LicenseAlias")
 @Table(name = "license_alias", indexes = {
-        @Index(name = LicenseAlias.IDX_NAME_LICENSE_ALIAS_LICENSE, columnList = "license_id") }, uniqueConstraints = {
-                @UniqueConstraint(name = LicenseAlias.UC_NAME_ALIAS_NAME, columnNames = { "alias_name" }) })
+        @Index(name = LicenseAlias.IDX_NAME_LICENSE_ALIAS_LICENSE, columnList = "license_id") })
 
 @ToString
 @EqualsAndHashCode

--- a/src/main/java/org/jboss/license/dictionary/utils/QueryUtils.java
+++ b/src/main/java/org/jboss/license/dictionary/utils/QueryUtils.java
@@ -45,6 +45,10 @@ public class QueryUtils {
         // From https://github.com/jirutka/rsql-parser/blob/v2.1.0/src/main/java/cz/jirutka/rsql/parser/RSQLParser.java
         // reserved = '"' | "'" | "(" | ")" | ";" | "," | "=" | "!" | "~" | "<" | ">" | " ";
 
+        if (rsqlArgument == null) {
+            return null;
+        }
+
         return rsqlArgument.replace("'", "\\'").replace("!", "\\!").replace("|", "\\|").replace("\"", "\\\"")
                 .replace(";", "\\;").replace(",", "\\,").replace("=", "\\=").replace("~", "\\~").replace("<", "\\<")
                 .replace(">", "\\>");

--- a/src/main/java/org/jboss/license/dictionary/utils/QueryUtils.java
+++ b/src/main/java/org/jboss/license/dictionary/utils/QueryUtils.java
@@ -41,4 +41,13 @@ public class QueryUtils {
         }
     }
 
+    public static String escapeReservedChars(String rsqlArgument) {
+        // From https://github.com/jirutka/rsql-parser/blob/v2.1.0/src/main/java/cz/jirutka/rsql/parser/RSQLParser.java
+        // reserved = '"' | "'" | "(" | ")" | ";" | "," | "=" | "!" | "~" | "<" | ">" | " ";
+
+        return rsqlArgument.replace("'", "\\'").replace("!", "\\!").replace("|", "\\|").replace("\"", "\\\"")
+                .replace(";", "\\;").replace(",", "\\,").replace("=", "\\=").replace("~", "\\~").replace("<", "\\<")
+                .replace(">", "\\>");
+    }
+
 }

--- a/src/main/java/org/jboss/license/dictionary/utils/rsql/CustomizedPredicateBuilder.java
+++ b/src/main/java/org/jboss/license/dictionary/utils/rsql/CustomizedPredicateBuilder.java
@@ -112,13 +112,13 @@ public class CustomizedPredicateBuilder {
      */
     public static <T> Predicate createPredicate(LogicalNode logical, From root, Class<T> entity, EntityManager entityManager,
             BuilderTools misc) {
-        log.infof("Creating Predicate for logical node: %s", logical);
+        log.debugf("Creating Predicate for logical node: %s", logical);
 
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
 
         List<Predicate> predicates = new ArrayList<Predicate>();
 
-        log.infof("Creating Predicates from all children nodes.");
+        log.debugf("Creating Predicates from all children nodes.");
         for (Node node : logical.getChildren()) {
             predicates.add(createPredicate(node, root, entity, entityManager, misc));
         }
@@ -150,12 +150,12 @@ public class CustomizedPredicateBuilder {
             log.log(Level.FATAL, msg);
             throw new IllegalArgumentException(msg);
         }
-        log.infof("Creating Predicate for comparison node: %s", comparison);
+        log.debugf("Creating Predicate for comparison node: %s", comparison);
 
-        log.infof("Property graph path : %s", comparison.getSelector());
+        log.debugf("Property graph path : %s", comparison.getSelector());
         Expression propertyPath = findPropertyPath(comparison.getSelector(), startRoot, entityManager, misc);
 
-        log.infof("Cast all arguments to type %s.", propertyPath.getJavaType().getName());
+        log.debugf("Cast all arguments to type %s.", propertyPath.getJavaType().getName());
         List<Object> castedArguments = misc.getArgumentParser().parse(comparison.getArguments(), propertyPath.getJavaType());
 
         try {
@@ -213,7 +213,7 @@ public class CustomizedPredicateBuilder {
                         root = root.get(mappedProperty);
                     }
                 } else {
-                    log.infof("Create property path for type %s property %s.",
+                    log.debugf("Create property path for type %s property %s.",
                             new Object[] { classMetadata.getJavaType().getName(), mappedProperty });
                     root = root.get(mappedProperty);
 
@@ -241,7 +241,7 @@ public class CustomizedPredicateBuilder {
      */
     private static Predicate createPredicate(Expression propertyPath, ComparisonOperator operator, List<Object> arguments,
             EntityManager manager) {
-        log.infof("Creating predicate: propertyPath %s %s", new Object[] { operator, arguments });
+        log.debugf("Creating predicate: propertyPath %s %s", new Object[] { operator, arguments });
 
         if (ComparisonOperatorProxy.asEnum(operator) != null) {
             switch (ComparisonOperatorProxy.asEnum(operator)) {

--- a/src/main/ui/src/app/license.service.ts
+++ b/src/main/ui/src/app/license.service.ts
@@ -35,7 +35,7 @@ export class LicenseService {
 
     findLicenses(searchTerm: string, maxCount: number, offset: number): Observable<LicenseList> {
         let params = new HttpParams()
-            .set('searchTerm', searchTerm)
+            .set('search', searchTerm)
             .set('offset', offset.toString())
             .set('count', maxCount.toString());
 
@@ -47,7 +47,7 @@ export class LicenseService {
 
     findLicensesByCode(code: string, maxCount: number, offset: number): Observable<LicenseList> {
         let params = new HttpParams()
-            .set('code', code)
+            .set('query', "code=='" + this.escapeRsqlArgument(code) + "'")
             .set('offset', offset.toString())
             .set('count', maxCount.toString());
 
@@ -59,7 +59,7 @@ export class LicenseService {
 
     findLicensesByFedoraName(fedoraName: string, maxCount: number, offset: number): Observable<LicenseList> {
         let params = new HttpParams()
-            .set('fedoraName', fedoraName)
+            .set('query', "fedoraName=='" + this.escapeRsqlArgument(fedoraName) + "'")
             .set('offset', offset.toString())
             .set('count', maxCount.toString());
 
@@ -71,7 +71,7 @@ export class LicenseService {
 
     findLicensesBySpdxName(spdxName: string, maxCount: number, offset: number): Observable<LicenseList> {
         let params = new HttpParams()
-            .set('spdxName', spdxName)
+            .set('query', "spdxName=='" + this.escapeRsqlArgument(spdxName) + "'")
             .set('offset', offset.toString())
             .set('count', maxCount.toString());
 
@@ -124,6 +124,12 @@ export class LicenseService {
     getLicenseApprovalStatus(id): Observable<LicenseApprovalStatus> {
 
         return this.http.get<LicenseApprovalStatus>(RestConfigService.LICENSE_STATUS_ENDPOINT + `/${id}`);
+    }
+
+    escapeRsqlArgument(argument: string) {
+        return argument.replace("'", "\\'").replace("!", "\\!").replace("|", "\\|").replace("\"", "\\\"")
+                .replace(";", "\\;").replace(",", "\\,").replace("=", "\\=").replace("~", "\\~").replace("<", "\\<")
+                .replace(">", "\\>");
     }
 
     private responseToLicenseList = (response, _) => {

--- a/src/main/ui/src/app/list/list.component.html
+++ b/src/main/ui/src/app/list/list.component.html
@@ -41,7 +41,7 @@
 		<div class="input-group input-group-md add-on">
 			<input appAutofocus type="text" class="form-control search-query"
 				[(ngModel)]="searchTerm" (keyup.enter)="searchForLicenses(0)"
-				placeholder="Enter a search term" name="name" />
+				placeholder="Enter a search term (search will be exact match; use * as wildcards)" name="name" />
 			<div class="input-group-btn">
 				<button class="btn btn-default" type="button"
 					(click)="searchForLicenses(0)">

--- a/src/main/ui/src/app/list/list.component.html
+++ b/src/main/ui/src/app/list/list.component.html
@@ -41,7 +41,7 @@
 		<div class="input-group input-group-md add-on">
 			<input appAutofocus type="text" class="form-control search-query"
 				[(ngModel)]="searchTerm" (keyup.enter)="searchForLicenses(0)"
-				placeholder="Enter a search term (search will be exact match; use * as wildcards)" name="name" />
+				placeholder="Enter a search term (search will be exact match; use * as wildcard)" name="name" />
 			<div class="input-group-btn">
 				<button class="btn btn-default" type="button"
 					(click)="searchForLicenses(0)">

--- a/src/test/java/org/jboss/license/dictionary/license/LicenseResourceTest.java
+++ b/src/test/java/org/jboss/license/dictionary/license/LicenseResourceTest.java
@@ -115,11 +115,11 @@ public class LicenseResourceTest {
     // public static final String MY_LICENSE_URL = "http://example.com/license/text.txt";
     // public static final String MY_LICENSE_NAME = "mylicense";
 
-    public static final String APACHE_20_FEDORA_ABBR = "ASL 2.0";
-    public static final String APACHE_20_FEDORA_NAME = "Apache Software License 2.0";
-    public static final String APACHE_20_SPDX_ABBR = "Apache-2.0";
-    public static final String APACHE_20_SPDX_NAME = "Apache License 2.0";
-    public static final String APACHE_20_URL = "http://www.apache.org/licenses/LICENSE-2.0";
+    public static final String TEST_APACHE_20_FEDORA_ABBR = "TEST_ASL 2.0";
+    public static final String TEST_APACHE_20_FEDORA_NAME = "TEST_Apache Software License 2.0";
+    public static final String TEST_APACHE_20_SPDX_ABBR = "TEST_Apache-2.0";
+    public static final String TEST_APACHE_20_SPDX_NAME = "TEST_Apache License 2.0";
+    public static final String TEST_APACHE_20_URL = "TEST_http://www.apache.org/licenses/LICENSE-2.0";
 
     @Inject
     private LicenseEndpoint licenseEndpoint;
@@ -217,22 +217,23 @@ public class LicenseResourceTest {
         LicenseApprovalStatusRest APPROVED = (LicenseApprovalStatusRest) licenseStatusEndpoint
                 .getSpecificLicenseApprovalStatus(1).getEntity();
 
-        if (getLicenses(null, null, null, null, APACHE_20_FEDORA_NAME).isEmpty()) {
-            LicenseRest license = LicenseRest.Builder.newBuilder().code(APACHE_20_SPDX_ABBR).fedoraName(APACHE_20_FEDORA_NAME)
-                    .fedoraAbbreviation(APACHE_20_FEDORA_ABBR).spdxName(APACHE_20_SPDX_NAME)
-                    .spdxAbbreviation(APACHE_20_SPDX_ABBR).url(APACHE_20_URL).licenseApprovalStatus(APPROVED).build();
+        if (getLicenses(null, null, null, null, TEST_APACHE_20_FEDORA_NAME).isEmpty()) {
+            LicenseRest license = LicenseRest.Builder.newBuilder().code(TEST_APACHE_20_SPDX_ABBR)
+                    .fedoraName(TEST_APACHE_20_FEDORA_NAME).fedoraAbbreviation(TEST_APACHE_20_FEDORA_ABBR)
+                    .spdxName(TEST_APACHE_20_SPDX_NAME).spdxAbbreviation(TEST_APACHE_20_SPDX_ABBR).url(TEST_APACHE_20_URL)
+                    .licenseApprovalStatus(APPROVED).build();
 
             license = (LicenseRest) licenseEndpoint.createNewLicense(license, getUriInfo()).getEntity();
 
-            license.addAlias(null, "The Apache License, Version 2.0", license.getId());
-            license.addAlias(null, "apache-2.0", license.getId());
-            license.addAlias(null, "Apache License Version 2.0", license.getId());
-            license.addAlias(null, "Apache Software License, Version 2.0", license.getId());
-            license.addAlias(null, "Apache v2", license.getId());
-            license.addAlias(null, "The Apache Software License, Version 2.0", license.getId());
-            license.addAlias(null, "Apache License, Version 2.0", license.getId());
-            license.addAlias(null, "Apache-2.0", license.getId());
-            license.addAlias(null, "Apache Software License 2.0", license.getId());
+            license.addAlias(null, "TEST_The Apache License, Version 2.0", license.getId());
+            license.addAlias(null, "TEST_apache-2.0", license.getId());
+            license.addAlias(null, "TEST_Apache License Version 2.0", license.getId());
+            license.addAlias(null, "TEST_Apache Software License, Version 2.0", license.getId());
+            license.addAlias(null, "TEST_Apache v2", license.getId());
+            license.addAlias(null, "TEST_The Apache Software License, Version 2.0", license.getId());
+            license.addAlias(null, "TEST_Apache License, Version 2.0", license.getId());
+            license.addAlias(null, "TEST_Apache-2.0", license.getId());
+            license.addAlias(null, "TEST_Apache Software License 2.0", license.getId());
 
             license = (LicenseRest) licenseEndpoint.updateLicense(license.getId(), license).getEntity();
         }
@@ -292,9 +293,9 @@ public class LicenseResourceTest {
     public void shouldGetLicenseByFedoraName() {
         System.out.println("=== shouldGetLicenseByFedoraName");
 
-        LicenseRest mylicense = getLicenses(APACHE_20_FEDORA_NAME, null, null, null, null).iterator().next();
+        LicenseRest mylicense = getLicenses(TEST_APACHE_20_FEDORA_NAME, null, null, null, null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
     }
 
     @Test
@@ -302,9 +303,9 @@ public class LicenseResourceTest {
     public void shouldGetLicenseBySpdxName() {
         System.out.println("=== shouldGetLicenseBySpdxName");
 
-        LicenseRest mylicense = getLicenses(null, APACHE_20_SPDX_NAME, null, null, null).iterator().next();
+        LicenseRest mylicense = getLicenses(null, TEST_APACHE_20_SPDX_NAME, null, null, null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
     }
 
     @Test
@@ -312,9 +313,9 @@ public class LicenseResourceTest {
     public void shouldGetLicenseByCode() {
         System.out.println("=== shouldGetLicenseByCode");
 
-        LicenseRest mylicense = getLicenses(null, null, APACHE_20_SPDX_ABBR, null, null).iterator().next();
+        LicenseRest mylicense = getLicenses(null, null, TEST_APACHE_20_SPDX_ABBR, null, null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
     }
 
     @Test
@@ -322,9 +323,9 @@ public class LicenseResourceTest {
     public void shouldGetLicenseByFedoraAbbreviation() {
         System.out.println("=== shouldGetLicenseByFedoraAbbreviation");
 
-        LicenseRest mylicense = getLicenses(null, null, null, null, APACHE_20_FEDORA_ABBR).iterator().next();
+        LicenseRest mylicense = getLicenses(null, null, null, null, TEST_APACHE_20_FEDORA_ABBR).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
     }
 
     @Test
@@ -332,9 +333,9 @@ public class LicenseResourceTest {
     public void shouldGetLicenseBySpdxAbbreviation() {
         System.out.println("=== shouldGetLicenseBySpdxAbbreviation");
 
-        LicenseRest mylicense = getLicenses(null, null, null, null, APACHE_20_SPDX_ABBR).iterator().next();
+        LicenseRest mylicense = getLicenses(null, null, null, null, TEST_APACHE_20_SPDX_ABBR).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
     }
 
     @Test
@@ -342,41 +343,41 @@ public class LicenseResourceTest {
     public void shouldGetLicenseByAliases() {
         System.out.println("=== shouldGetLicenseByAliases");
 
-        LicenseRest mylicense = getLicenses(null, null, null, "The Apache License, Version 2.0", null).iterator().next();
+        LicenseRest mylicense = getLicenses(null, null, null, "TEST_The Apache License, Version 2.0", null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
 
-        mylicense = getLicenses(null, null, null, "apache-2.0", null).iterator().next();
+        mylicense = getLicenses(null, null, null, "TEST_apache-2.0", null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
 
-        mylicense = getLicenses(null, null, null, "Apache License Version 2.0", null).iterator().next();
+        mylicense = getLicenses(null, null, null, "TEST_Apache License Version 2.0", null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
 
-        mylicense = getLicenses(null, null, null, "Apache Software License, Version 2.0", null).iterator().next();
+        mylicense = getLicenses(null, null, null, "TEST_Apache Software License, Version 2.0", null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
 
-        mylicense = getLicenses(null, null, null, "Apache v2", null).iterator().next();
+        mylicense = getLicenses(null, null, null, "TEST_Apache v2", null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
 
-        mylicense = getLicenses(null, null, null, "The Apache Software License, Version 2.0", null).iterator().next();
+        mylicense = getLicenses(null, null, null, "TEST_The Apache Software License, Version 2.0", null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
 
-        mylicense = getLicenses(null, null, null, "Apache License, Version 2.0", null).iterator().next();
+        mylicense = getLicenses(null, null, null, "TEST_Apache License, Version 2.0", null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
 
-        mylicense = getLicenses(null, null, null, "Apache-2.0", null).iterator().next();
+        mylicense = getLicenses(null, null, null, "TEST_Apache-2.0", null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
 
-        mylicense = getLicenses(null, null, null, "Apache Software License 2.0", null).iterator().next();
+        mylicense = getLicenses(null, null, null, "TEST_Apache Software License 2.0", null).iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
 
     }
 
@@ -410,11 +411,11 @@ public class LicenseResourceTest {
     public void shouldGetLicenseByExactSearchTerm() {
         System.out.println("=== shouldGetLicenseByExactSearchTerm");
 
-        Collection<LicenseRest> licenses = getLicenses(null, null, null, null, APACHE_20_FEDORA_NAME);
+        Collection<LicenseRest> licenses = getLicenses(null, null, null, null, TEST_APACHE_20_FEDORA_NAME);
         assertThat(licenses).hasSize(1);
         LicenseRest mylicense = licenses.iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
     }
 
     @Test
@@ -422,13 +423,13 @@ public class LicenseResourceTest {
     public void shouldGetLicenseBySubstringSearchTerm() {
         System.out.println("=== shouldGetLicenseBySubstringSearchTerm");
 
-        String subString = "*" + APACHE_20_FEDORA_NAME.substring(1, APACHE_20_FEDORA_NAME.length() - 1) + "*";
+        String subString = "*" + TEST_APACHE_20_FEDORA_NAME.substring(1, TEST_APACHE_20_FEDORA_NAME.length() - 1) + "*";
 
         Collection<LicenseRest> licenses = getLicenses(null, null, null, null, subString);
         assertThat(licenses).hasSize(1);
         LicenseRest mylicense = licenses.iterator().next();
         assertThat(mylicense).isNotNull();
-        assertThat(mylicense.getUrl()).isEqualTo(APACHE_20_URL);
+        assertThat(mylicense.getUrl()).isEqualTo(TEST_APACHE_20_URL);
     }
 
     @Test
@@ -462,7 +463,7 @@ public class LicenseResourceTest {
 
         LicenseApprovalStatusRest APPROVED = (LicenseApprovalStatusRest) licenseStatusEndpoint
                 .getSpecificLicenseApprovalStatus(LicenseApprovalStatusRest.APPROVED.getId()).getEntity();
-        LicenseRest license = LicenseRest.Builder.newBuilder().fedoraName(APACHE_20_FEDORA_NAME).url("by-id.example.com")
+        LicenseRest license = LicenseRest.Builder.newBuilder().fedoraName(TEST_APACHE_20_FEDORA_NAME).url("by-id.example.com")
                 .code("licenseReadById").licenseApprovalStatus(APPROVED).build();
 
         try {
@@ -1229,7 +1230,7 @@ public class LicenseResourceTest {
         ProjectVersionLicenseCheckRest projectVersionLicenseCheckRest1 = projVersLicenseCheckRestList.get(0);
         ProjectVersionLicenseCheckRest projectVersionLicenseCheckRest2 = projVersLicenseCheckRestList.get(1);
 
-        String subString = "*" + APACHE_20_FEDORA_NAME.substring(1, APACHE_20_FEDORA_NAME.length() - 1) + "*";
+        String subString = "*" + TEST_APACHE_20_FEDORA_NAME.substring(1, TEST_APACHE_20_FEDORA_NAME.length() - 1) + "*";
 
         Collection<LicenseRest> licenses = getLicenses(null, null, null, null, subString);
         assertThat(licenses).hasSize(1);

--- a/src/test/resources/test_import_license_aliases.json
+++ b/src/test/resources/test_import_license_aliases.json
@@ -378,9 +378,6 @@
   "Dotseqn License": [
     "Dotseqn"
   ],
-  "Dual license consisting of the CDDL v1.1 and GPL v2": [
-    
-  ],
   "EU DataGrid Software License": [
     "EUDatagrid"
   ],

--- a/src/test/resources/test_import_license_aliases.json
+++ b/src/test/resources/test_import_license_aliases.json
@@ -496,6 +496,7 @@
   ],
   "GNU General Public License v2.0 w/Classpath exception": [
     "GNU General Public License v2.0 only, with Classpath exception",
+    "GNU General Public License, Version 2 with the Classpath Exception",
     "GPL-2.0-with-classpath-exception"
   ],
   "GNU General Public License v2.0 w/Font exception": [

--- a/src/test/resources/test_import_url_rh_license.json
+++ b/src/test/resources/test_import_url_rh_license.json
@@ -98,6 +98,17 @@
     "spdx_name": "Abstyles License",
     "url": "https://fedoraproject.org/wiki/Licensing/Abstyles"
   },
+  "Academic Free License": {
+    "approved": "yes",
+    "fedora_abbrev": "AFL",
+    "fedora_name": "Academic Free License",
+    "id": "5",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/AFL-3.0.txt",
+    "spdx_abbrev": "AFL-3.0",
+    "spdx_license_url": "https://spdx.org/licenses/AFL-3.0.html#licenseText",
+    "spdx_name": "Academic Free License v3.0",
+    "url": "http://opensource.org/licenses/afl-3.0.php"
+  },
   "Academic Free License v1.1": {
     "approved": "unknown",
     "fedora_abbrev": "",
@@ -164,6 +175,17 @@
     "spdx_name": "Academy of Motion Picture Arts and Sciences BSD",
     "url": "https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD"
   },
+  "Adaptive Public License": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "Adaptive Public License",
+    "id": "12",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/APL-1.0.txt",
+    "spdx_abbrev": "APL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/APL-1.0.html#licenseText",
+    "spdx_name": "Adaptive Public License 1.0",
+    "url": "https://opensource.org/licenses/apl1.0.php"
+  },
   "Adaptive Public License 1.0": {
     "approved": "no",
     "fedora_abbrev": "",
@@ -208,14 +230,25 @@
     "spdx_name": "Adobe Systems Incorporated Source Code License Agreement",
     "url": "https://fedoraproject.org/wiki/Licensing/AdobeLicense"
   },
-  "GNU Affero General Public License v3.0": {
+  "Affero General Public License 1.0": {
+    "approved": "yes",
+    "fedora_abbrev": "AGPLv1",
+    "fedora_name": "Affero General Public License 1.0",
+    "id": "17",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/AGPL-1.0.txt",
+    "spdx_abbrev": "AGPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/AGPL-1.0.html#licenseText",
+    "spdx_name": "Affero General Public License v1.0",
+    "url": "http://www.affero.org/oagpl.html"
+  },
+  "Affero General Public License 3.0": {
     "approved": "yes",
     "fedora_abbrev": "AGPLv3",
     "fedora_name": "Affero General Public License 3.0",
-    "id": "215",
+    "id": "18",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/AGPL-3.0.txt",
     "spdx_abbrev": "AGPL-3.0",
-    "spdx_license_url": "https://spdx.org/licenses/AGPL-3.0.html#licenseText",
+    "spdx_license_url": "",
     "spdx_name": "GNU Affero General Public License v3.0",
     "url": "https://spdx.org/licenses/AGPL-3.0.html"
   },
@@ -334,6 +367,83 @@
     "fedora_abbrev": "ASL 2.0",
     "fedora_name": "Apache Software License 2.0",
     "id": "32",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Apache-2.0.txt",
+    "spdx_abbrev": "Apache-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/Apache-2.0.html#licenseText",
+    "spdx_name": "Apache License 2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0"
+  },
+  "Apache License Version 2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "ASL 2.0",
+    "fedora_name": "Apache Software License 2.0",
+    "id": "574",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Apache-2.0.txt",
+    "spdx_abbrev": "Apache-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/Apache-2.0.html#licenseText",
+    "spdx_name": "Apache License 2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0"
+  },
+  "Apache License, Version 2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "ASL 2.0",
+    "fedora_name": "Apache Software License 2.0",
+    "id": "579",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Apache-2.0.txt",
+    "spdx_abbrev": "Apache-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/Apache-2.0.html#licenseText",
+    "spdx_name": "Apache License 2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0"
+  },
+  "Apache Software License 1.0": {
+    "approved": "yes",
+    "fedora_abbrev": "ASL 1.0",
+    "fedora_name": "Apache Software License 1.0",
+    "id": "33",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Apache-1.0.txt",
+    "spdx_abbrev": "Apache-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/Apache-1.0.html#licenseText",
+    "spdx_name": "Apache License 1.0",
+    "url": "http://www.apache.org/licenses/LICENSE-1.0"
+  },
+  "Apache Software License 1.1": {
+    "approved": "yes",
+    "fedora_abbrev": "ASL 1.1",
+    "fedora_name": "Apache Software License 1.1",
+    "id": "34",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Apache-1.1.txt",
+    "spdx_abbrev": "Apache-1.1",
+    "spdx_license_url": "https://spdx.org/licenses/Apache-1.1.html#licenseText",
+    "spdx_name": "Apache License 1.1",
+    "url": "http://www.apache.org/licenses/LICENSE-1.1"
+  },
+  "Apache Software License 2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "ASL 2.0",
+    "fedora_name": "Apache Software License 2.0",
+    "id": "35",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Apache-2.0.txt",
+    "spdx_abbrev": "Apache-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/Apache-2.0.html#licenseText",
+    "spdx_name": "Apache License 2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0"
+  },
+  "Apache Software License, Version 2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "ASL 2.0",
+    "fedora_name": "Apache Software License 2.0",
+    "id": "36",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Apache-2.0.txt",
+    "spdx_abbrev": "Apache-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/Apache-2.0.html#licenseText",
+    "spdx_name": "Apache License 2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0"
+  },
+  "Apache v2": {
+    "approved": "yes",
+    "fedora_abbrev": "ASL 2.0",
+    "fedora_name": "Apache Software License 2.0",
+    "id": "575",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Apache-2.0.txt",
     "spdx_abbrev": "Apache-2.0",
     "spdx_license_url": "https://spdx.org/licenses/Apache-2.0.html#licenseText",
@@ -461,11 +571,11 @@
     "spdx_name": "",
     "url": "http://dev.perl.org/licenses/artistic.html"
   },
-  "Artistic License 2.0": {
+  "Artistic 2.0": {
     "approved": "yes",
     "fedora_abbrev": "Artistic 2.0",
     "fedora_name": "Artistic 2.0",
-    "id": "52",
+    "id": "47",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Artistic-2.0.txt",
     "spdx_abbrev": "Artistic-2.0",
     "spdx_license_url": "https://spdx.org/licenses/Artistic-2.0.html#licenseText",
@@ -504,6 +614,17 @@
     "spdx_license_url": "https://spdx.org/licenses/Artistic-1.0-cl8.html#licenseText",
     "spdx_name": "Artistic License 1.0 w/clause 8",
     "url": "http://opensource.org/licenses/Artistic-1.0"
+  },
+  "Artistic License 2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "Artistic 2.0",
+    "fedora_name": "Artistic 2.0",
+    "id": "52",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Artistic-2.0.txt",
+    "spdx_abbrev": "Artistic-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/Artistic-2.0.html#licenseText",
+    "spdx_name": "Artistic License 2.0",
+    "url": "http://www.perlfoundation.org/artistic_license_2_0"
   },
   "Aspell-ru License": {
     "approved": "yes",
@@ -769,6 +890,17 @@
     "spdx_name": "",
     "url": "https://fedoraproject.org/wiki/Licensing/Bibtex"
   },
+  "BitTorrent License": {
+    "approved": "yes",
+    "fedora_abbrev": "BitTorrent",
+    "fedora_name": "BitTorrent License",
+    "id": "61",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/BitTorrent-1.1.txt",
+    "spdx_abbrev": "BitTorrent-1.1",
+    "spdx_license_url": "https://spdx.org/licenses/BitTorrent-1.1.html#licenseText",
+    "spdx_name": "BitTorrent Open Source License v1.1",
+    "url": "https://fedoraproject.org/wiki/Licensing/BitTorrent_Open_Source_License"
+  },
   "BitTorrent Open Source License v1.0": {
     "approved": "unknown",
     "fedora_abbrev": "",
@@ -790,6 +922,17 @@
     "spdx_license_url": "https://spdx.org/licenses/BitTorrent-1.1.html#licenseText",
     "spdx_name": "BitTorrent Open Source License v1.1",
     "url": "https://fedoraproject.org/wiki/Licensing/BitTorrent_Open_Source_License"
+  },
+  "Boost Software License": {
+    "approved": "yes",
+    "fedora_abbrev": "Boost",
+    "fedora_name": "Boost Software License",
+    "id": "64",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/BSL-1.0.txt",
+    "spdx_abbrev": "BSL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/BSL-1.0.html#licenseText",
+    "spdx_name": "Boost Software License 1.0",
+    "url": "http://www.boost.org/LICENSE_1_0.txt"
   },
   "Boost Software License 1.0": {
     "approved": "yes",
@@ -912,15 +1055,15 @@
     "spdx_name": "CNRI Python Open Source GPL Compatible License Agreement",
     "url": "http://www.python.org/download/releases/1.6.1/download_win/"
   },
-  "Common Public Attribution License 1.0": {
+  "CPAL License 1.0": {
     "approved": "yes",
     "fedora_abbrev": "CPAL",
     "fedora_name": "CPAL License 1.0",
-    "id": "115",
-    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CPAL-1.0.txt",
-    "spdx_abbrev": "CPAL-1.0",
-    "spdx_license_url": "https://spdx.org/licenses/CPAL-1.0.html#licenseText",
-    "spdx_name": "Common Public Attribution License 1.0",
+    "id": "123",
+    "license_text_url": "",
+    "spdx_abbrev": "",
+    "spdx_license_url": "",
+    "spdx_name": "",
     "url": "https://www.socialtext.net/open/index.cgi?cpal_license_in_wikitext"
   },
   "CRC32 License": {
@@ -934,7 +1077,7 @@
     "spdx_name": "",
     "url": "https://fedoraproject.org/wiki/Licensing/CRC32"
   },
-  "CUA Office Public License v1.0": {
+  "CUA Office Public License Version 1.0": {
     "approved": "yes",
     "fedora_abbrev": "MPLv1.1",
     "fedora_name": "CUA Office Public License Version 1.0",
@@ -1000,6 +1143,28 @@
     "spdx_name": "CeCILL Free Software License Agreement v2.1",
     "url": "http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.html"
   },
+  "CeCILL License v1.1": {
+    "approved": "yes",
+    "fedora_abbrev": "CeCILL",
+    "fedora_name": "CeCILL License v1.1",
+    "id": "97",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CECILL-1.1.txt",
+    "spdx_abbrev": "CECILL-1.1",
+    "spdx_license_url": "https://spdx.org/licenses/CECILL-1.1.html#licenseText",
+    "spdx_name": "CeCILL Free Software License Agreement v1.1",
+    "url": "http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html"
+  },
+  "CeCILL License v2": {
+    "approved": "yes",
+    "fedora_abbrev": "CeCILL",
+    "fedora_name": "CeCILL License v2",
+    "id": "98",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CECILL-2.0.txt",
+    "spdx_abbrev": "CECILL-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/CECILL-2.0.html#licenseText",
+    "spdx_name": "CeCILL Free Software License Agreement v2.0",
+    "url": "http://www.cecill.info/licences/Licence_CeCILL_V2-fr.html"
+  },
   "CeCILL-B Free Software License Agreement": {
     "approved": "yes",
     "fedora_abbrev": "CeCILL-B",
@@ -1011,11 +1176,33 @@
     "spdx_name": "CeCILL-B Free Software License Agreement",
     "url": "http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.html"
   },
+  "CeCILL-B License": {
+    "approved": "yes",
+    "fedora_abbrev": "CeCILL-B",
+    "fedora_name": "CeCILL-B License",
+    "id": "90",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CECILL-B.txt",
+    "spdx_abbrev": "CECILL-B",
+    "spdx_license_url": "https://spdx.org/licenses/CECILL-B.html#licenseText",
+    "spdx_name": "CeCILL-B Free Software License Agreement",
+    "url": "http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.html"
+  },
   "CeCILL-C Free Software License Agreement": {
     "approved": "yes",
     "fedora_abbrev": "CeCILL-C",
     "fedora_name": "CeCILL-C License",
     "id": "91",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CECILL-C.txt",
+    "spdx_abbrev": "CECILL-C",
+    "spdx_license_url": "https://spdx.org/licenses/CECILL-C.html#licenseText",
+    "spdx_name": "CeCILL-C Free Software License Agreement",
+    "url": "http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.html"
+  },
+  "CeCILL-C License": {
+    "approved": "yes",
+    "fedora_abbrev": "CeCILL-C",
+    "fedora_name": "CeCILL-C License",
+    "id": "92",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CECILL-C.txt",
     "spdx_abbrev": "CECILL-C",
     "spdx_license_url": "https://spdx.org/licenses/CECILL-C.html#licenseText",
@@ -1055,6 +1242,39 @@
     "spdx_name": "Code Project Open License 1.02",
     "url": "http://www.codeproject.com/info/cpol10.aspx"
   },
+  "CodeProject Open License (CPOL)": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "CodeProject Open License (CPOL)",
+    "id": "109",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CPOL-1.02.txt",
+    "spdx_abbrev": "CPOL-1.02",
+    "spdx_license_url": "https://spdx.org/licenses/CPOL-1.02.html#licenseText",
+    "spdx_name": "Code Project Open License 1.02",
+    "url": "http://www.codeproject.com/info/cpol10.aspx"
+  },
+  "Common Development Distribution License": {
+    "approved": "yes",
+    "fedora_abbrev": "CDDL-1.0",
+    "fedora_name": "Common Development Distribution License 1.0",
+    "id": "114",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CDDL-1.0.txt",
+    "spdx_abbrev": "CDDL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/CDDL-1.0.html#licenseText",
+    "spdx_name": "Common Development and Distribution License 1.0",
+    "url": "http://repository.jboss.org/licenses/cddl.txt"
+  },
+  "Common Development and Distribution License": {
+    "approved": "yes",
+    "fedora_abbrev": "CDDL-1.0",
+    "fedora_name": "Common Development Distribution License 1.0",
+    "id": "110",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CDDL-1.0.txt",
+    "spdx_abbrev": "CDDL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/CDDL-1.0.html#licenseText",
+    "spdx_name": "Common Development and Distribution License 1.0",
+    "url": "http://repository.jboss.org/licenses/cddl.txt"
+  },
   "Common Development and Distribution License (CDDL) and GNU Public License v.2 w/Classpath Exception": {
     "approved": "yes",
     "fedora_abbrev": "",
@@ -1065,6 +1285,17 @@
     "spdx_license_url": "",
     "spdx_name": "",
     "url": "https://netbeans.org/cddl-gplv2.html"
+  },
+  "Common Development Distribution License 1.0": {
+    "approved": "yes",
+    "fedora_abbrev": "CDDL-1.0",
+    "fedora_name": "Common Development Distribution License 1.0",
+    "id": "111",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CDDL-1.0.txt",
+    "spdx_abbrev": "CDDL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/CDDL-1.0.html#licenseText",
+    "spdx_name": "Common Development and Distribution License 1.0",
+    "url": "http://repository.jboss.org/licenses/cddl.txt"
   },
   "Common Development and Distribution License 1.0": {
     "approved": "yes",
@@ -1077,6 +1308,17 @@
     "spdx_name": "Common Development and Distribution License 1.0",
     "url": "http://repository.jboss.org/licenses/cddl.txt"
   },
+  "Common Development Distribution License 1.1": {
+    "approved": "yes",
+    "fedora_abbrev": "CDDL-1.1",
+    "fedora_name": "Common Development Distribution License 1.1",
+    "id": "112",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CDDL-1.1.txt",
+    "spdx_abbrev": "CDDL-1.1",
+    "spdx_license_url": "https://spdx.org/licenses/CDDL-1.1.html#licenseText",
+    "spdx_name": "Common Development and Distribution License 1.1",
+    "url": "https://javaee.github.io/glassfish/LICENSE"
+  },
   "Common Development and Distribution License 1.1": {
     "approved": "yes",
     "fedora_abbrev": "CDDL-1.1",
@@ -1088,11 +1330,55 @@
     "spdx_name": "Common Development and Distribution License 1.1",
     "url": "https://javaee.github.io/glassfish/LICENSE"
   },
+  "Common Development and Distribution License version 1.1": {
+    "approved": "yes",
+    "fedora_abbrev": "CDDL-1.1",
+    "fedora_name": "Common Development Distribution License 1.1",
+    "id": "113",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CDDL-1.1.txt",
+    "spdx_abbrev": "CDDL-1.1",
+    "spdx_license_url": "https://spdx.org/licenses/CDDL-1.1.html#licenseText",
+    "spdx_name": "Common Development and Distribution License 1.1",
+    "url": "https://javaee.github.io/glassfish/LICENSE"
+  },
+  "Common Public Attribution License 1.0": {
+    "approved": "unknown",
+    "fedora_abbrev": "",
+    "fedora_name": "",
+    "id": "115",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CPAL-1.0.txt",
+    "spdx_abbrev": "CPAL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/CPAL-1.0.html#licenseText",
+    "spdx_name": "Common Public Attribution License 1.0",
+    "url": "https://www.socialtext.net/open/index.cgi?cpal_license_in_wikitext"
+  },
+  "Common Public License": {
+    "approved": "yes",
+    "fedora_abbrev": "CPL",
+    "fedora_name": "Common Public License",
+    "id": "116",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CPL-1.0.txt",
+    "spdx_abbrev": "CPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/CPL-1.0.html#licenseText",
+    "spdx_name": "Common Public License 1.0",
+    "url": "http://www.eclipse.org/legal/cpl-v10.html"
+  },
   "Common Public License 1.0": {
     "approved": "yes",
     "fedora_abbrev": "CPL",
     "fedora_name": "Common Public License",
     "id": "117",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CPL-1.0.txt",
+    "spdx_abbrev": "CPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/CPL-1.0.html#licenseText",
+    "spdx_name": "Common Public License 1.0",
+    "url": "http://www.eclipse.org/legal/cpl-v10.html"
+  },
+  "Common Public License, Version 1.0": {
+    "approved": "yes",
+    "fedora_abbrev": "CPL",
+    "fedora_name": "Common Public License",
+    "id": "118",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CPL-1.0.txt",
     "spdx_abbrev": "CPL-1.0",
     "spdx_license_url": "https://spdx.org/licenses/CPL-1.0.html#licenseText",
@@ -1506,6 +1792,17 @@
     "spdx_name": "",
     "url": "http://creativecommons.org/choose/cc-lgpl"
   },
+  "Creative Commons Zero 1.0 Universal": {
+    "approved": "yes",
+    "fedora_abbrev": "CC0",
+    "fedora_name": "Creative Commons Zero 1.0 Universal",
+    "id": "158",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CC0-1.0.txt",
+    "spdx_abbrev": "CC0-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/CC0-1.0.html#licenseText",
+    "spdx_name": "Creative Commons Zero v1.0 Universal",
+    "url": "http://creativecommons.org/publicdomain/zero/1.0/legalcode"
+  },
   "Creative Commons Zero v1.0 Universal": {
     "approved": "yes",
     "fedora_abbrev": "CC0",
@@ -1539,7 +1836,7 @@
     "spdx_name": "",
     "url": "http://www.cryptix.org/LICENSE.TXT"
   },
-  "CrystalStacker License": {
+  "Crystal Stacker License": {
     "approved": "yes",
     "fedora_abbrev": "Crystal Stacker",
     "fedora_name": "Crystal Stacker License",
@@ -1693,9 +1990,31 @@
     "spdx_name": "",
     "url": "http://repository.jboss.org/licenses/edl-1.0.txt"
   },
+  "Eclipse Distribution License, Version 1.0": {
+    "approved": "yes",
+    "fedora_abbrev": "BSD",
+    "fedora_name": "Eclipse Distribution License 1.0",
+    "id": "176",
+    "license_text_url": "",
+    "spdx_abbrev": "",
+    "spdx_license_url": "",
+    "spdx_name": "",
+    "url": "http://repository.jboss.org/licenses/edl-1.0.txt"
+  },
+  "Eclipse Public License - v 1.0": {
+    "approved": "yes",
+    "fedora_abbrev": "EPL",
+    "fedora_name": "Eclipse Public License 1.0",
+    "id": "580",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/EPL-1.0.txt",
+    "spdx_abbrev": "EPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/EPL-1.0.html#licenseText",
+    "spdx_name": "Eclipse Public License 1.0",
+    "url": "http://www.eclipse.org/legal/epl-v10.html"
+  },
   "Eclipse Public License 1.0": {
     "approved": "yes",
-    "fedora_abbrev": "EPL-1.0",
+    "fedora_abbrev": "EPL",
     "fedora_name": "Eclipse Public License 1.0",
     "id": "177",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/EPL-1.0.txt",
@@ -1704,7 +2023,18 @@
     "spdx_name": "Eclipse Public License 1.0",
     "url": "http://www.eclipse.org/legal/epl-v10.html"
   },
-  "Eclipse Public License 2.0": {
+  "Eclipse Public License, Version 1.0": {
+    "approved": "yes",
+    "fedora_abbrev": "EPL",
+    "fedora_name": "Eclipse Public License 1.0",
+    "id": "178",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/EPL-1.0.txt",
+    "spdx_abbrev": "EPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/EPL-1.0.html#licenseText",
+    "spdx_name": "Eclipse Public License 1.0",
+    "url": "http://www.eclipse.org/legal/epl-v10.html"
+  },
+  "Eclipse Public License - v 2.0": {
     "approved": "yes",
     "fedora_abbrev": "",
     "fedora_name": "",
@@ -1715,7 +2045,7 @@
     "spdx_name": "Eclipse Public License 2.0",
     "url": "http://www.eclipse.org/legal/epl-v20.html"
   },
-  "Educational Community License v1.0": {
+  "Educational Community License 1.0": {
     "approved": "yes",
     "fedora_abbrev": "ECL 1.0",
     "fedora_name": "Educational Community License 1.0",
@@ -1726,7 +2056,7 @@
     "spdx_name": "Educational Community License v1.0",
     "url": "http://opensource.org/licenses/ecl1.php"
   },
-  "Educational Community License v2.0": {
+  "Educational Community License 2.0": {
     "approved": "yes",
     "fedora_abbrev": "ECL 2.0",
     "fedora_name": "Educational Community License 2.0",
@@ -1737,7 +2067,7 @@
     "spdx_name": "Educational Community License v2.0",
     "url": "http://www.osedu.org/licenses/ECL-2.0/"
   },
-  "Eiffel Forum License v1.0": {
+  "Eiffel Forum License 1.0": {
     "approved": "no",
     "fedora_abbrev": "",
     "fedora_name": "Eiffel Forum License 1.0",
@@ -1748,7 +2078,7 @@
     "spdx_name": "Eiffel Forum License v1.0",
     "url": "http://www.eiffel-nice.org/license/forum.txt"
   },
-  "Eiffel Forum License v2.0": {
+  "Eiffel Forum License 2.0": {
     "approved": "yes",
     "fedora_abbrev": "EFL 2.0",
     "fedora_name": "Eiffel Forum License 2.0",
@@ -1770,6 +2100,17 @@
     "spdx_name": "Enlightenment License (e16)",
     "url": "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
   },
+  "Entessa Public License": {
+    "approved": "yes",
+    "fedora_abbrev": "Entessa",
+    "fedora_name": "Entessa Public License",
+    "id": "189",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Entessa.txt",
+    "spdx_abbrev": "Entessa",
+    "spdx_license_url": "https://spdx.org/licenses/Entessa.html#licenseText",
+    "spdx_name": "Entessa Public License v1.0",
+    "url": "http://opensource.org/licenses/entessa.php"
+  },
   "Entessa Public License v1.0": {
     "approved": "yes",
     "fedora_abbrev": "Entessa",
@@ -1781,7 +2122,7 @@
     "spdx_name": "Entessa Public License v1.0",
     "url": "http://opensource.org/licenses/entessa.php"
   },
-  "Erlang Public License v1.1": {
+  "Erlang Public License 1.1": {
     "approved": "yes",
     "fedora_abbrev": "ERPL",
     "fedora_name": "Erlang Public License 1.1",
@@ -1814,6 +2155,17 @@
     "spdx_name": "European Union Public License 1.1",
     "url": "http://ec.europa.eu/idabc/en/document/7774.html"
   },
+  "European Union Public License v1.0": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "European Union Public License v1.0",
+    "id": "196",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/EUPL-1.0.txt",
+    "spdx_abbrev": "EUPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/EUPL-1.0.html#licenseText",
+    "spdx_name": "European Union Public License 1.0",
+    "url": "http://ec.europa.eu/idabc/en/document/7330.html"
+  },
   "Eurosym License": {
     "approved": "yes",
     "fedora_abbrev": "Eurosym",
@@ -1837,9 +2189,9 @@
     "url": "http://www.fltk.org/COPYING.php"
   },
   "FSF All Permissive License": {
-    "approved": "yes",
-    "fedora_abbrev": "FSFAP",
-    "fedora_name": "FSF All Permissive license",
+    "approved": "unknown",
+    "fedora_abbrev": "",
+    "fedora_name": "",
     "id": "209",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/FSFAP.txt",
     "spdx_abbrev": "FSFAP",
@@ -1891,6 +2243,17 @@
     "spdx_name": "",
     "url": "http://directory.fedoraproject.org/wiki/GPL_Exception_License_Text"
   },
+  "Frameworx License": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "Frameworx License",
+    "id": "202",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Frameworx-1.0.txt",
+    "spdx_abbrev": "Frameworx-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/Frameworx-1.0.html#licenseText",
+    "spdx_name": "Frameworx Open License 1.0",
+    "url": "http://www.opensource.org/licenses/Frameworx-1.0"
+  },
   "Frameworx Open License 1.0": {
     "approved": "no",
     "fedora_abbrev": "",
@@ -1902,6 +2265,17 @@
     "spdx_name": "Frameworx Open License 1.0",
     "url": "http://www.opensource.org/licenses/Frameworx-1.0"
   },
+  "FreeImage Public License": {
+    "approved": "yes",
+    "fedora_abbrev": "MPLv1.0",
+    "fedora_name": "FreeImage Public License",
+    "id": "204",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/FreeImage.txt",
+    "spdx_abbrev": "FreeImage",
+    "spdx_license_url": "https://spdx.org/licenses/FreeImage.html#licenseText",
+    "spdx_name": "FreeImage Public License v1.0",
+    "url": "http://freeimage.sourceforge.net/freeimage-license.txt"
+  },
   "FreeImage Public License v1.0": {
     "approved": "yes",
     "fedora_abbrev": "MPLv1.0",
@@ -1912,6 +2286,17 @@
     "spdx_license_url": "https://spdx.org/licenses/FreeImage.html#licenseText",
     "spdx_name": "FreeImage Public License v1.0",
     "url": "http://freeimage.sourceforge.net/freeimage-license.txt"
+  },
+  "Freetype License": {
+    "approved": "yes",
+    "fedora_abbrev": "FTL",
+    "fedora_name": "Freetype License",
+    "id": "206",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/FTL.txt",
+    "spdx_abbrev": "FTL",
+    "spdx_license_url": "https://spdx.org/licenses/FTL.html#licenseText",
+    "spdx_name": "Freetype Project License",
+    "url": "http://freetype.fis.uniroma2.it/FTL.TXT"
   },
   "Freetype Project License": {
     "approved": "yes",
@@ -1945,6 +2330,17 @@
     "spdx_license_url": "https://spdx.org/licenses/GL2PS.html#licenseText",
     "spdx_name": "GL2PS License",
     "url": "http://www.geuz.org/gl2ps/COPYING.GL2PS"
+  },
+  "GNU Affero General Public License v3.0": {
+    "approved": "yes",
+    "fedora_abbrev": "",
+    "fedora_name": "",
+    "id": "215",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/AGPL-3.0.txt",
+    "spdx_abbrev": "AGPL-3.0",
+    "spdx_license_url": "https://spdx.org/licenses/AGPL-3.0.html#licenseText",
+    "spdx_name": "GNU Affero General Public License v3.0",
+    "url": "https://spdx.org/licenses/AGPL-3.0.html"
   },
   "GNU Free Documentation License v1.1": {
     "approved": "unknown",
@@ -2045,22 +2441,22 @@
     "spdx_name": "GNU General Public License v2.0 only",
     "url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
   },
-  "GNU General Public License v2.0 w/Classpath exception": {
+  "GNU General Public License v2.0 only, with Classpath exception": {
     "approved": "yes",
     "fedora_abbrev": "GPLv2 with exceptions",
     "fedora_name": "GNU General Public License v2.0 only, with Classpath exception",
-    "id": "565",
+    "id": "225",
     "license_text_url": "http://repository.jboss.org/licenses/gpl-2.0-ce.txt",
     "spdx_abbrev": "GPL-2.0-with-classpath-exception",
     "spdx_license_url": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html#licenseText",
     "spdx_name": "GNU General Public License v2.0 w/Classpath exception",
     "url": "https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception"
   },
-  "GNU General Public License v2.0 w/Font exception": {
+  "GNU General Public License v2.0 only, with font embedding exception": {
     "approved": "yes",
     "fedora_abbrev": "GPLv2 with exceptions",
     "fedora_name": "GNU General Public License v2.0 only, with font embedding exception",
-    "id": "566",
+    "id": "226",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/depreciate_GPL-2.0-with-font-exception.txt",
     "spdx_abbrev": "GPL-2.0-with-font-exception",
     "spdx_license_url": "https://spdx.org/licenses/GPL-2.0-with-font-exception.html#licenseText",
@@ -2121,6 +2517,28 @@
     "spdx_license_url": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.html#licenseText",
     "spdx_name": "GNU General Public License v2.0 w/Bison exception",
     "url": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.html"
+  },
+  "GNU General Public License v2.0 w/Classpath exception": {
+    "approved": "yes",
+    "fedora_abbrev": "GPLv2 with exceptions",
+    "fedora_name": "GNU General Public License v2.0 only, with Classpath exception",
+    "id": "565",
+    "license_text_url": "http://repository.jboss.org/licenses/gpl-2.0-ce.txt",
+    "spdx_abbrev": "GPL-2.0-with-classpath-exception",
+    "spdx_license_url": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html#licenseText",
+    "spdx_name": "GNU General Public License v2.0 w/Classpath exception",
+    "url": "https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception"
+  },
+  "GNU General Public License v2.0 w/Font exception": {
+    "approved": "yes",
+    "fedora_abbrev": "GPLv2 with exceptions",
+    "fedora_name": "GNU General Public License v2.0 only, with font embedding exception",
+    "id": "566",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/depreciate_GPL-2.0-with-font-exception.txt",
+    "spdx_abbrev": "GPL-2.0-with-font-exception",
+    "spdx_license_url": "https://spdx.org/licenses/GPL-2.0-with-font-exception.html#licenseText",
+    "spdx_name": "GNU General Public License v2.0 w/Font exception",
+    "url": "http://www.gnu.org/licenses/gpl-faq.html#FontException"
   },
   "GNU General Public License v2.0 w/GCC Runtime Library exception": {
     "approved": "unknown",
@@ -2287,6 +2705,17 @@
     "spdx_name": "",
     "url": ""
   },
+  "GNU Lesser General Public License v2.1 only": {
+    "approved": "yes",
+    "fedora_abbrev": "",
+    "fedora_name": "",
+    "id": "238",
+    "license_text_url": "http://repository.jboss.org/licenses/lgpl-2.1.txt",
+    "spdx_abbrev": "LGPL-2.1",
+    "spdx_license_url": "https://spdx.org/licenses/LGPL-2.1.html#licenseText",
+    "spdx_name": "GNU Lesser General Public License v2.1 only",
+    "url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+  },
   "GNU Lesser General Public License v2.1 or later": {
     "approved": "yes",
     "fedora_abbrev": "",
@@ -2297,6 +2726,17 @@
     "spdx_license_url": "https://spdx.org/licenses/LGPL-2.1+.html#licenseText",
     "spdx_name": "GNU Lesser General Public License v2.1 or later",
     "url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
+  },
+  "GNU Lesser General Public License v3.0 only": {
+    "approved": "yes",
+    "fedora_abbrev": "LGPLv3",
+    "fedora_name": "GNU Lesser General Public License v3.0 only",
+    "id": "243",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/LGPL-3.0.txt",
+    "spdx_abbrev": "LGPL-3.0",
+    "spdx_license_url": "https://spdx.org/licenses/LGPL-3.0.html#licenseText",
+    "spdx_name": "GNU Lesser General Public License v3.0 only",
+    "url": "http://www.gnu.org/licenses/lgpl-3.0-standalone.html"
   },
   "GNU Lesser General Public License v3.0 only, with exceptions": {
     "approved": "yes",
@@ -2331,22 +2771,22 @@
     "spdx_name": "",
     "url": ""
   },
-  "GNU Lesser General Public License v2.1 only": {
+  "GNU Lesser General Public License, Version 2.1": {
     "approved": "yes",
     "fedora_abbrev": "",
     "fedora_name": "",
-    "id": "238",
+    "id": "247",
     "license_text_url": "http://repository.jboss.org/licenses/lgpl-2.1.txt",
     "spdx_abbrev": "LGPL-2.1",
     "spdx_license_url": "https://spdx.org/licenses/LGPL-2.1.html#licenseText",
     "spdx_name": "GNU Lesser General Public License v2.1 only",
     "url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
   },
-  "GNU Lesser General Public License v3.0 only": {
+  "GNU Lesser General Public License, Version 3": {
     "approved": "yes",
     "fedora_abbrev": "LGPLv3",
     "fedora_name": "GNU Lesser General Public License v3.0 only",
-    "id": "243",
+    "id": "248",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/LGPL-3.0.txt",
     "spdx_abbrev": "LGPL-3.0",
     "spdx_license_url": "https://spdx.org/licenses/LGPL-3.0.html#licenseText",
@@ -2374,6 +2814,17 @@
     "spdx_license_url": "https://spdx.org/licenses/LGPL-2.0+.html#licenseText",
     "spdx_name": "GNU Library General Public License v2 or later",
     "url": "https://spdx.org/licenses/LGPL-2.0+.html"
+  },
+  "GNU Library General Public License, Version 2": {
+    "approved": "yes",
+    "fedora_abbrev": "",
+    "fedora_name": "",
+    "id": "250",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/LGPL-2.0.txt",
+    "spdx_abbrev": "LGPL-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/LGPL-2.0.html#licenseText",
+    "spdx_name": "GNU Library General Public License v2 only",
+    "url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
   },
   "GPL for Computer Programs of the Public Administration": {
     "approved": "no",
@@ -2485,6 +2936,17 @@
     "spdx_name": "Historic Permission Notice and Disclaimer",
     "url": "http://opensource.org/licenses/historical.php"
   },
+  "Historical Permission Notice and Disclaimer": {
+    "approved": "yes",
+    "fedora_abbrev": "MIT",
+    "fedora_name": "Historical Permission Notice and Disclaimer",
+    "id": "260",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/HPND.txt",
+    "spdx_abbrev": "HPND",
+    "spdx_license_url": "https://spdx.org/licenses/HPND.html#licenseText",
+    "spdx_name": "Historic Permission Notice and Disclaimer",
+    "url": "http://opensource.org/licenses/historical.php"
+  },
   "IBM PowerPC Initialization and Boot Software": {
     "approved": "unknown",
     "fedora_abbrev": "",
@@ -2495,6 +2957,17 @@
     "spdx_license_url": "https://spdx.org/licenses/IBM-pibs.html#licenseText",
     "spdx_name": "IBM PowerPC Initialization and Boot Software",
     "url": "http://git.denx.de/?p=u-boot.git;a=blob;f=arch/powerpc/cpu/ppc4xx/miiphy.c;h=297155fdafa064b955e53e9832de93bfb0cfb85b;hb=9fab4bf4cc077c21e43941866f3f2c196f28670d"
+  },
+  "IBM Public License": {
+    "approved": "yes",
+    "fedora_abbrev": "IBM",
+    "fedora_name": "IBM Public License",
+    "id": "264",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/IPL-1.0.txt",
+    "spdx_abbrev": "IPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/IPL-1.0.html#licenseText",
+    "spdx_name": "IBM Public License v1.0",
+    "url": "http://www.opensource.org/licenses/IPL-1.0"
   },
   "IBM Public License v1.0": {
     "approved": "yes",
@@ -2529,7 +3002,7 @@
     "spdx_name": "",
     "url": "http://source.icu-project.org/repos/icu/trunk/icu4j/main/shared/licenses/LICENSE"
   },
-  "ICU License": {
+  "ICU License - ICU 1.8.1 to ICU 57.1": {
     "approved": "unknown",
     "fedora_abbrev": "",
     "fedora_name": "",
@@ -2540,22 +3013,22 @@
     "spdx_name": "ICU License",
     "url": "http://source.icu-project.org/repos/icu/tags/release-57-1/icu4j/main/shared/licenses/LICENSE"
   },
-  "IPA Font License": {
-    "approved": "yes",
-    "fedora_abbrev": "IPA",
-    "fedora_name": "IPA Font License",
-    "id": "278",
-    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/IPA.txt",
-    "spdx_abbrev": "IPA",
-    "spdx_license_url": "https://spdx.org/licenses/IPA.html#licenseText",
-    "spdx_name": "IPA Font License",
-    "url": "https://fedoraproject.org/wiki/Licensing/IPAFontLicense"
-  },
   "ISC License": {
     "approved": "yes",
     "fedora_abbrev": "ISC",
     "fedora_name": "ISC License (Bind, DHCP Server)",
     "id": "279",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/ISC.txt",
+    "spdx_abbrev": "ISC",
+    "spdx_license_url": "https://spdx.org/licenses/ISC.html#licenseText",
+    "spdx_name": "ISC License",
+    "url": "http://www.isc.org/downloads/software-support-policy/isc-license/"
+  },
+  "ISC License (Bind, DHCP Server)": {
+    "approved": "yes",
+    "fedora_abbrev": "ISC",
+    "fedora_name": "ISC License (Bind, DHCP Server)",
+    "id": "280",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/ISC.txt",
     "spdx_abbrev": "ISC",
     "spdx_license_url": "https://spdx.org/licenses/ISC.html#licenseText",
@@ -2606,6 +3079,28 @@
     "spdx_name": "",
     "url": "https://enterprise.dejacode.com/licenses/public/indiana-extreme/?_list_filters=q%3Dindiana%2Bextreme#license-text"
   },
+  "Indiana University Extreme! Lab Software License Version 1.1.1": {
+    "approved": "yes",
+    "fedora_abbrev": "",
+    "fedora_name": "",
+    "id": "584",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Indiana_Extreme_License_1.1.1.txt",
+    "spdx_abbrev": "",
+    "spdx_license_url": "",
+    "spdx_name": "",
+    "url": "https://enterprise.dejacode.com/licenses/public/indiana-extreme/?_list_filters=q%3Dindiana%2Bextreme#license-text"
+  },
+  "indiana-extreme": {
+    "approved": "yes",
+    "fedora_abbrev": "",
+    "fedora_name": "",
+    "id": "585",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Indiana_Extreme_License_1.1.1.txt",
+    "spdx_abbrev": "",
+    "spdx_license_url": "",
+    "spdx_name": "",
+    "url": "https://enterprise.dejacode.com/licenses/public/indiana-extreme/?_list_filters=q%3Dindiana%2Bextreme#license-text"
+  },
   "Info-ZIP License": {
     "approved": "unknown",
     "fedora_abbrev": "",
@@ -2649,6 +3144,17 @@
     "spdx_license_url": "https://spdx.org/licenses/Intel.html#licenseText",
     "spdx_name": "Intel Open Source License",
     "url": "http://opensource.org/licenses/Intel"
+  },
+  "Interbase Public License": {
+    "approved": "yes",
+    "fedora_abbrev": "Interbase",
+    "fedora_name": "Interbase Public License",
+    "id": "276",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Interbase-1.0.txt",
+    "spdx_abbrev": "Interbase-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/Interbase-1.0.html#licenseText",
+    "spdx_name": "Interbase Public License v1.0",
+    "url": "https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html"
   },
   "Interbase Public License v1.0": {
     "approved": "yes",
@@ -2759,6 +3265,28 @@
     "spdx_license_url": "",
     "spdx_name": "",
     "url": "https://fedoraproject.org/wiki/Licensing/LOSLA"
+  },
+  "LGPL 2.1": {
+    "approved": "yes",
+    "fedora_abbrev": "",
+    "fedora_name": "",
+    "id": "583",
+    "license_text_url": "http://repository.jboss.org/licenses/lgpl-2.1.txt",
+    "spdx_abbrev": "LGPL-2.1",
+    "spdx_license_url": "https://spdx.org/licenses/LGPL-2.1.html#licenseText",
+    "spdx_name": "GNU Lesser General Public License v2.1 only",
+    "url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+  },
+  "LaTeX Project Public License": {
+    "approved": "yes",
+    "fedora_abbrev": "LPPL",
+    "fedora_name": "LaTeX Project Public License",
+    "id": "290",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/LPPL-1.3a.txt",
+    "spdx_abbrev": "LPPL-1.3a",
+    "spdx_license_url": "https://spdx.org/licenses/LPPL-1.3a.html#licenseText",
+    "spdx_name": "LaTeX Project Public License v1.3a",
+    "url": "http://www.latex-project.org/lppl/lppl-1-3a.txt"
   },
   "LaTeX Project Public License v1.0": {
     "approved": "unknown",
@@ -3046,6 +3574,17 @@
     "spdx_name": "",
     "url": "http://opensource.org/licenses/mitrepl.php"
   },
+  "MPL 1.1": {
+    "approved": "yes",
+    "fedora_abbrev": "MPLv1.1",
+    "fedora_name": "Mozilla Public License v1.1",
+    "id": "582",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/MPL-1.1.txt",
+    "spdx_abbrev": "MPL-1.1",
+    "spdx_license_url": "https://spdx.org/licenses/MPL-1.1.html#licenseText",
+    "spdx_name": "Mozilla Public License 1.1",
+    "url": "http://www.mozilla.org/MPL/MPL-1.1.html"
+  },
   "MSNTP License": {
     "approved": "no",
     "fedora_abbrev": "",
@@ -3167,7 +3706,7 @@
     "spdx_name": "",
     "url": "https://fedoraproject.org/wiki/Licensing/Microsoft_Shared_Source_License"
   },
-  "MirOS Licence": {
+  "MirOS License": {
     "approved": "yes",
     "fedora_abbrev": "MirOS",
     "fedora_name": "MirOS License",
@@ -3233,6 +3772,50 @@
     "spdx_name": "Mozilla Public License 2.0 (no copyleft exception)",
     "url": "http://www.mozilla.org/MPL/2.0/"
   },
+  "Mozilla Public License v1.0": {
+    "approved": "yes",
+    "fedora_abbrev": "MPLv1.0",
+    "fedora_name": "Mozilla Public License v1.0",
+    "id": "338",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/MPL-1.0.txt",
+    "spdx_abbrev": "MPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/MPL-1.0.html#licenseText",
+    "spdx_name": "Mozilla Public License 1.0",
+    "url": "http://opensource.org/licenses/mozilla1.0.php"
+  },
+  "Mozilla Public License v1.1": {
+    "approved": "yes",
+    "fedora_abbrev": "MPLv1.1",
+    "fedora_name": "Mozilla Public License v1.1",
+    "id": "339",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/MPL-1.1.txt",
+    "spdx_abbrev": "MPL-1.1",
+    "spdx_license_url": "https://spdx.org/licenses/MPL-1.1.html#licenseText",
+    "spdx_name": "Mozilla Public License 1.1",
+    "url": "http://www.mozilla.org/MPL/MPL-1.1.html"
+  },
+  "Mozilla Public License v2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "MPLv2.0",
+    "fedora_name": "Mozilla Public License v2.0",
+    "id": "340",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/MPL-2.0.txt",
+    "spdx_abbrev": "MPL-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/MPL-2.0.html#licenseText",
+    "spdx_name": "Mozilla Public License 2.0",
+    "url": "https://fedoraproject.org/wiki/Licensing/MPLv2.0"
+  },
+  "Mozilla Public License, Version 1.1": {
+    "approved": "yes",
+    "fedora_abbrev": "MPLv1.1",
+    "fedora_name": "Mozilla Public License v1.1",
+    "id": "341",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/MPL-1.1.txt",
+    "spdx_abbrev": "MPL-1.1",
+    "spdx_license_url": "https://spdx.org/licenses/MPL-1.1.html#licenseText",
+    "spdx_name": "Mozilla Public License 1.1",
+    "url": "http://www.mozilla.org/MPL/MPL-1.1.html"
+  },
   "Multics License": {
     "approved": "unknown",
     "fedora_abbrev": "",
@@ -3288,17 +3871,29 @@
     "spdx_name": "NASA Open Source Agreement 1.3",
     "url": "http://ti.arc.nasa.gov/opensource/nosa/"
   },
-  "University of Illinois/NCSA Open Source License": {
+  "NASA Open Source Agreement v1.3": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "NASA Open Source Agreement v1.3",
+    "id": "351",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/NASA-1.3.txt",
+    "spdx_abbrev": "NASA-1.3",
+    "spdx_license_url": "https://spdx.org/licenses/NASA-1.3.html#licenseText",
+    "spdx_name": "NASA Open Source Agreement 1.3",
+    "url": "http://ti.arc.nasa.gov/opensource/nosa/"
+  },
+  "NCSA/University of Illinois Open Source License": {
     "approved": "yes",
     "fedora_abbrev": "NCSA",
     "fedora_name": "NCSA/University of Illinois Open Source License",
-    "id": "524",
+    "id": "353",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/NCSA.txt",
     "spdx_abbrev": "NCSA",
     "spdx_license_url": "https://spdx.org/licenses/NCSA.html#licenseText",
     "spdx_name": "University of Illinois/NCSA Open Source License",
     "url": "http://otm.illinois.edu/uiuc_openSource"
   },
+
   "NRL License": {
     "approved": "yes",
     "fedora_abbrev": "BSD with advertising",
@@ -3397,6 +3992,17 @@
     "spdx_license_url": "https://spdx.org/licenses/NOSL.html#licenseText",
     "spdx_name": "Netizen Open Source License",
     "url": "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
+  },
+  "Netscape Public License": {
+    "approved": "yes",
+    "fedora_abbrev": "Netscape",
+    "fedora_name": "Netscape Public License",
+    "id": "359",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/NPL-1.0.txt",
+    "spdx_abbrev": "NPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/NPL-1.0.html#licenseText",
+    "spdx_name": "Netscape Public License v1.0",
+    "url": "http://www.mozilla.org/MPL/NPL/1.0/"
   },
   "Netscape Public License v1.0": {
     "approved": "yes",
@@ -3518,6 +4124,17 @@
     "spdx_license_url": "https://spdx.org/licenses/Nunit.html#licenseText",
     "spdx_name": "Nunit License",
     "url": "https://fedoraproject.org/wiki/Licensing/Nunit"
+  },
+  "OCLC Public Research License 2.0": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "OCLC Public Research License 2.0",
+    "id": "374",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/OCLC-2.0.txt",
+    "spdx_abbrev": "OCLC-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/OCLC-2.0.html#licenseText",
+    "spdx_name": "OCLC Research Public License 2.0",
+    "url": "http://www.oclc.org/research/activities/software/license/v2final.htm"
   },
   "OCLC Research Public License 2.0": {
     "approved": "no",
@@ -3827,6 +4444,17 @@
     "spdx_name": "",
     "url": "http://www.opengroup.org/openmotif/license/"
   },
+  "Open Public License": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "Open Public License",
+    "id": "402",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/OPL-1.0.txt",
+    "spdx_abbrev": "OPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/OPL-1.0.html#licenseText",
+    "spdx_name": "Open Public License v1.0",
+    "url": "https://fedoraproject.org/wiki/Licensing/Open_Public_License"
+  },
   "Open Public License v1.0": {
     "approved": "no",
     "fedora_abbrev": "",
@@ -4070,6 +4698,17 @@
     "spdx_name": "",
     "url": ""
   },
+  "Public Domain, per Creative Commons CC0": {
+    "approved": "yes",
+    "fedora_abbrev": "CC0",
+    "fedora_name": "Creative Commons Zero 1.0 Universal",
+    "id": "581",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CC0-1.0.txt",
+    "spdx_abbrev": "CC0-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/CC0-1.0.html#licenseText",
+    "spdx_name": "Creative Commons Zero v1.0 Universal",
+    "url": "http://creativecommons.org/publicdomain/zero/1.0/legalcode"
+  },
   "Python License": {
     "approved": "yes",
     "fedora_abbrev": "Python",
@@ -4312,6 +4951,17 @@
     "spdx_name": "",
     "url": "http://oss.sgi.com/projects/FreeB/"
   },
+  "SGI Free Software License B 2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "MIT",
+    "fedora_name": "SGI Free Software License B 2.0",
+    "id": "461",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/SGI-B-2.0.txt",
+    "spdx_abbrev": "SGI-B-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/SGI-B-2.0.html#licenseText",
+    "spdx_name": "SGI Free Software License B v2.0",
+    "url": "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
+  },
   "SGI Free Software License B v1.0": {
     "approved": "unknown",
     "fedora_abbrev": "",
@@ -4521,6 +5171,17 @@
     "spdx_name": "Sleepycat License",
     "url": "https://fedoraproject.org/wiki/Licensing/Sleepycat"
   },
+  "Sleepycat Software Product License": {
+    "approved": "yes",
+    "fedora_abbrev": "Sleepycat",
+    "fedora_name": "Sleepycat Software Product License",
+    "id": "471",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Sleepycat.txt",
+    "spdx_abbrev": "Sleepycat",
+    "spdx_license_url": "https://spdx.org/licenses/Sleepycat.html#licenseText",
+    "spdx_name": "Sleepycat License",
+    "url": "https://fedoraproject.org/wiki/Licensing/Sleepycat"
+  },
   "Spencer License 86": {
     "approved": "unknown",
     "fedora_abbrev": "",
@@ -4620,6 +5281,17 @@
     "spdx_name": "",
     "url": "http://www.sun.com/software/communitysource/"
   },
+  "Sun Industry Standards Source License": {
+    "approved": "yes",
+    "fedora_abbrev": "SISSL",
+    "fedora_name": "Sun Industry Standards Source License",
+    "id": "484",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/SISSL.txt",
+    "spdx_abbrev": "SISSL",
+    "spdx_license_url": "https://spdx.org/licenses/SISSL.html#licenseText",
+    "spdx_name": "Sun Industry Standards Source License v1.1",
+    "url": "http://www.openoffice.org/licenses/sissl_license.html"
+  },
   "Sun Industry Standards Source License v1.1": {
     "approved": "yes",
     "fedora_abbrev": "SISSL",
@@ -4641,6 +5313,17 @@
     "spdx_license_url": "https://spdx.org/licenses/SISSL-1.2.html#licenseText",
     "spdx_name": "Sun Industry Standards Source License v1.2",
     "url": "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
+  },
+  "Sun Public License": {
+    "approved": "yes",
+    "fedora_abbrev": "SPL",
+    "fedora_name": "Sun Public License",
+    "id": "487",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/SPL-1.0.txt",
+    "spdx_abbrev": "SPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/SPL-1.0.html#licenseText",
+    "spdx_name": "Sun Public License v1.0",
+    "url": "https://fedoraproject.org/wiki/Licensing/Sun_Public_License"
   },
   "Sun Public License v1.0": {
     "approved": "yes",
@@ -4796,6 +5479,28 @@
     "spdx_name": "",
     "url": "http://www.antlr2.org/download/antlr-2.7.7.tar.gz"
   },
+  "The Apache License, Version 2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "ASL 2.0",
+    "fedora_name": "Apache Software License 2.0",
+    "id": "578",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Apache-2.0.txt",
+    "spdx_abbrev": "Apache-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/Apache-2.0.html#licenseText",
+    "spdx_name": "Apache License 2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0"
+  },
+  "The Apache Software License, Version 2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "ASL 2.0",
+    "fedora_name": "Apache Software License 2.0",
+    "id": "576",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Apache-2.0.txt",
+    "spdx_abbrev": "Apache-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/Apache-2.0.html#licenseText",
+    "spdx_name": "Apache License 2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0"
+  },
   "The Asm BSD License": {
     "approved": "yes",
     "fedora_abbrev": "",
@@ -4850,6 +5555,17 @@
     "spdx_license_url": "",
     "spdx_name": "",
     "url": "http://www.jaxen.org/license.html"
+  },
+  "The MIT License": {
+    "approved": "yes",
+    "fedora_abbrev": "",
+    "fedora_name": "",
+    "id": "504",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/MIT.txt",
+    "spdx_abbrev": "MIT",
+    "spdx_license_url": "https://spdx.org/licenses/MIT.html#licenseText",
+    "spdx_name": "MIT License",
+    "url": "http://www.opensource.org/licenses/MIT"
   },
   "The Unlicense": {
     "approved": "yes",
@@ -5027,6 +5743,17 @@
     "spdx_name": "Universal Permissive License v1.0",
     "url": "http://opensource.org/licenses/UPL"
   },
+  "University of Illinois/NCSA Open Source License": {
+    "approved": "yes",
+    "fedora_abbrev": "NCSA",
+    "fedora_name": "NCSA/University of Illinois Open Source License",
+    "id": "524",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/NCSA.txt",
+    "spdx_abbrev": "NCSA",
+    "spdx_license_url": "https://spdx.org/licenses/NCSA.html#licenseText",
+    "spdx_name": "University of Illinois/NCSA Open Source License",
+    "url": "http://otm.illinois.edu/uiuc_openSource"
+  },
   "University of Utah Public License": {
     "approved": "no",
     "fedora_abbrev": "",
@@ -5048,6 +5775,17 @@
     "spdx_license_url": "",
     "spdx_name": "",
     "url": "https://fedoraproject.org/wiki/Licensing:UofWFreeFork?rd=Licensing/UofWFreeFork"
+  },
+  "Unlicense": {
+    "approved": "yes",
+    "fedora_abbrev": "Unlicense",
+    "fedora_name": "Unlicense",
+    "id": "527",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Unlicense.txt",
+    "spdx_abbrev": "Unlicense",
+    "spdx_license_url": "https://spdx.org/licenses/Unlicense.html#licenseText",
+    "spdx_name": "The Unlicense",
+    "url": "http://unlicense.org/"
   },
   "VOSTROM Public License for Open Source": {
     "approved": "yes",
@@ -5082,6 +5820,17 @@
     "spdx_name": "",
     "url": "https://fedoraproject.org/wiki/Licensing/Vita_Nuova_Liberal_Source_License"
   },
+  "Vovida Software License v. 1.0": {
+    "approved": "yes",
+    "fedora_abbrev": "VSL",
+    "fedora_name": "Vovida Software License v. 1.0",
+    "id": "532",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/VSL-1.0.txt",
+    "spdx_abbrev": "VSL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/VSL-1.0.html#licenseText",
+    "spdx_name": "Vovida Software License v1.0",
+    "url": "http://opensource.org/licenses/vovidapl.php"
+  },
   "Vovida Software License v1.0": {
     "approved": "yes",
     "fedora_abbrev": "VSL",
@@ -5093,6 +5842,28 @@
     "spdx_name": "Vovida Software License v1.0",
     "url": "http://opensource.org/licenses/vovidapl.php"
   },
+  "W3C Document License": {
+    "approved": "no",
+    "fedora_abbrev": "W3C",
+    "fedora_name": "W3C Documentation License",
+    "id": "561",
+    "license_text_url": "",
+    "spdx_abbrev": "",
+    "spdx_license_url": "",
+    "spdx_name": "",
+    "url": "http://www.w3.org/Consortium/Legal/copyright-documents"
+  },
+  "W3C Software Notice and Document License (2002-12-31)": {
+    "approved": "yes",
+    "fedora_abbrev": "",
+    "fedora_name": "",
+    "id": "560",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/W3C.txt",
+    "spdx_abbrev": "W3C",
+    "spdx_license_url": "https://spdx.org/licenses/W3C.html#licenseText",
+    "spdx_name": "W3C Software Notice and License (2002-12-31)",
+    "url": "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html"
+  },
   "W3C Software Notice and Document License (2015-05-13)": {
     "approved": "unknown",
     "fedora_abbrev": "",
@@ -5103,6 +5874,17 @@
     "spdx_license_url": "https://spdx.org/licenses/W3C-20150513.html#licenseText",
     "spdx_name": "W3C Software Notice and Document License (2015-05-13)",
     "url": "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
+  },
+  "W3C Software Notice and License": {
+    "approved": "yes",
+    "fedora_abbrev": "W3C",
+    "fedora_name": "W3C Software Notice and License",
+    "id": "535",
+    "license_text_url": "",
+    "spdx_abbrev": "",
+    "spdx_license_url": "",
+    "spdx_name": "",
+    "url": "https://www.w3.org/Consortium/Legal/2002/copyright-software-20021231"
   },
   "W3C Software Notice and License (1998-07-20)": {
     "approved": "unknown",
@@ -5117,8 +5899,8 @@
   },
   "W3C Software Notice and License (2002-12-31)": {
     "approved": "yes",
-    "fedora_abbrev": "W3C",
-    "fedora_name": "W3C Software Notice and License",
+    "fedora_abbrev": "",
+    "fedora_name": "",
     "id": "537",
     "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/W3C.txt",
     "spdx_abbrev": "W3C",
@@ -5214,6 +5996,28 @@
     "spdx_name": "Xerox License",
     "url": "https://fedoraproject.org/wiki/Licensing/Xerox"
   },
+  "Yahoo Public License 1.0": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "Yahoo Public License 1.0",
+    "id": "548",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/YPL-1.0.txt",
+    "spdx_abbrev": "YPL-1.0",
+    "spdx_license_url": "https://spdx.org/licenses/YPL-1.0.html#licenseText",
+    "spdx_name": "Yahoo! Public License v1.0",
+    "url": "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
+  },
+  "Yahoo Public License v 1.1": {
+    "approved": "yes",
+    "fedora_abbrev": "YPLv1.1",
+    "fedora_name": "Yahoo Public License v 1.1",
+    "id": "550",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/YPL-1.1.txt",
+    "spdx_abbrev": "YPL-1.1",
+    "spdx_license_url": "https://spdx.org/licenses/YPL-1.1.html#licenseText",
+    "spdx_name": "Yahoo! Public License v1.1",
+    "url": "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
+  },
   "Yahoo! Public License v1.0": {
     "approved": "no",
     "fedora_abbrev": "",
@@ -5257,6 +6061,17 @@
     "spdx_license_url": "https://spdx.org/licenses/Zend-2.0.html#licenseText",
     "spdx_name": "Zend License v2.0",
     "url": "http://www.zend.com/license/2_00.txt"
+  },
+  "Zimbra Public License 1.3": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "Zimbra Public License 1.3",
+    "id": "554",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Zimbra-1.3.txt",
+    "spdx_abbrev": "Zimbra-1.3",
+    "spdx_license_url": "https://spdx.org/licenses/Zimbra-1.3.html#licenseText",
+    "spdx_name": "Zimbra Public License v1.3",
+    "url": "http://www.zimbra.com/license/zimbra-public-license-1-3.html"
   },
   "Zimbra Public License v1.3": {
     "approved": "no",
@@ -5324,6 +6139,39 @@
     "spdx_name": "",
     "url": "http://old.zope.org/Resources/License/ZPL-1.1"
   },
+  "Zope Public License v 2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "ZPLv2.0",
+    "fedora_name": "Zope Public License v 2.0",
+    "id": "564",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/ZPL-2.0.txt",
+    "spdx_abbrev": "ZPL-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/ZPL-2.0.html#licenseText",
+    "spdx_name": "Zope Public License 2.0",
+    "url": "http://old.zope.org/Resources/License/ZPL-2.0"
+  },
+  "Zope Public License v 2.1": {
+    "approved": "yes",
+    "fedora_abbrev": "ZPLv2.1",
+    "fedora_name": "Zope Public License v 2.1",
+    "id": "565",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/ZPL-2.1.txt",
+    "spdx_abbrev": "ZPL-2.1",
+    "spdx_license_url": "https://spdx.org/licenses/ZPL-2.1.html#licenseText",
+    "spdx_name": "Zope Public License 2.1",
+    "url": "http://old.zope.org/Resources/License/ZPL-2.1"
+  },
+  "apache-2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "ASL 2.0",
+    "fedora_name": "Apache Software License 2.0",
+    "id": "577",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Apache-2.0.txt",
+    "spdx_abbrev": "Apache-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/Apache-2.0.html#licenseText",
+    "spdx_name": "Apache License 2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0"
+  },
   "bzip2 and libbzip2 License v1.0.5": {
     "approved": "unknown",
     "fedora_abbrev": "",
@@ -5379,6 +6227,17 @@
     "spdx_name": "dvipdfm License",
     "url": "https://fedoraproject.org/wiki/Licensing/dvipdfm"
   },
+  "eCos License v2.0": {
+    "approved": "yes",
+    "fedora_abbrev": "eCos",
+    "fedora_name": "eCos License v2.0",
+    "id": "179",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/depreciate_eCos-2.0.txt",
+    "spdx_abbrev": "eCos-2.0",
+    "spdx_license_url": "https://spdx.org/licenses/eCos-2.0.html",
+    "spdx_name": "eCos license version 2.0",
+    "url": "http://www.gnu.org/licenses/ecos-license.html"
+  },
   "eCos Public License, v1.1": {
     "approved": "no",
     "fedora_abbrev": "",
@@ -5433,6 +6292,17 @@
     "spdx_license_url": "https://spdx.org/licenses/MIT-feh.html#licenseText",
     "spdx_name": "feh License",
     "url": "https://fedoraproject.org/wiki/Licensing/MIT#feh"
+  },
+  "gSOAP Public License": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "gSOAP Public License",
+    "id": "253",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/gSOAP-1.3b.txt",
+    "spdx_abbrev": "gSOAP-1.3b",
+    "spdx_license_url": "https://spdx.org/licenses/gSOAP-1.3b.html#licenseText",
+    "spdx_name": "gSOAP Public License v1.3b",
+    "url": "http://www.cs.fsu.edu/~engelen/license.html"
   },
   "gSOAP Public License v1.3b": {
     "approved": "no",
@@ -5654,6 +6524,17 @@
     "spdx_name": "zlib License",
     "url": "http://www.gzip.org/zlib/zlib_license.html"
   },
+  "zlib/libpng License": {
+    "approved": "yes",
+    "fedora_abbrev": "zlib",
+    "fedora_name": "zlib/libpng License",
+    "id": "557",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Zlib.txt",
+    "spdx_abbrev": "Zlib",
+    "spdx_license_url": "https://spdx.org/licenses/Zlib.html#licenseText",
+    "spdx_name": "zlib License",
+    "url": "http://www.gzip.org/zlib/zlib_license.html"
+  },
   "zlib/libpng License with Acknowledgement": {
     "approved": "yes",
     "fedora_abbrev": "zlib with acknowledgement",
@@ -5687,6 +6568,17 @@
     "spdx_name": "",
     "url": "https://fedoraproject.org/wiki/Licensing/FDK-AAC"
   },
+  "FSF All Permissive license": {
+    "approved": "yes",
+    "fedora_abbrev": "FSFAP",
+    "fedora_name": "FSF All Permissive license",
+    "id": "592",
+    "license_text_url": "",
+    "spdx_abbrev": "",
+    "spdx_license_url": "",
+    "spdx_name": "",
+    "url": "https://fedoraproject.org/wiki/Licensing/FSFAP"
+  },
   "SCRIP License": {
     "approved": "yes",
     "fedora_abbrev": "SCRIP",
@@ -5709,6 +6601,28 @@
     "spdx_name": "",
     "url": "https://fedoraproject.org/wiki/Licensing/Common_Documentation_License"
   },
+  "Creative Commons Attribution license": {
+    "approved": "yes",
+    "fedora_abbrev": "CC-BY",
+    "fedora_name": "Creative Commons Attribution license",
+    "id": "597",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CC-BY-3.0.txt",
+    "spdx_abbrev": "CC-BY-3.0",
+    "spdx_license_url": "https://spdx.org/licenses/CC-BY-3.0.html#licenseText",
+    "spdx_name": "Creative Commons Attribution 3.0",
+    "url": "http://creativecommons.org/licenses/by/3.0/"
+  },
+  "Creative Commons Attribution-ShareAlike": {
+    "approved": "yes",
+    "fedora_abbrev": "CC-BY-SA",
+    "fedora_name": "Creative Commons Attribution-ShareAlike",
+    "id": "598",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CC-BY-SA-3.0.txt",
+    "spdx_abbrev": "CC-BY-SA-3.0",
+    "spdx_license_url": "https://spdx.org/licenses/CC-BY-SA-3.0.html#licenseText",
+    "spdx_name": "Creative Commons Attribution Share Alike 3.0",
+    "url": "http://creativecommons.org/licenses/by-sa/3.0/"
+  },
   "FreeBSD Documentation License": {
     "approved": "yes",
     "fedora_abbrev": "FBSDDL",
@@ -5719,6 +6633,17 @@
     "spdx_license_url": "",
     "spdx_name": "",
     "url": "http://www.freebsd.org/copyright/freebsd-doc-license.html"
+  },
+  "GNU Free Documentation License": {
+    "approved": "yes",
+    "fedora_abbrev": "GFDL",
+    "fedora_name": "GNU Free Documentation License",
+    "id": "600",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/GFDL-1.3.txt",
+    "spdx_abbrev": "GFDL-1.3",
+    "spdx_license_url": "https://spdx.org/licenses/GFDL-1.3.html#licenseText",
+    "spdx_name": "GNU Free Documentation License v1.3",
+    "url": "http://www.fsf.org/licensing/licenses/fdl.html"
   },
   "IEEE and Open Group Documentation License": {
     "approved": "yes",
@@ -5819,6 +6744,17 @@
     "spdx_name": "",
     "url": "http://www.w3.org/Consortium/Legal/copyright-documents"
   },
+  "Creative Commons Attribution-NoDerivs": {
+    "approved": "yes",
+    "fedora_abbrev": "CC-BY-ND",
+    "fedora_name": "Creative Commons Attribution-NoDerivs",
+    "id": "610",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CC-BY-ND-3.0.txt",
+    "spdx_abbrev": "CC-BY-ND-3.0",
+    "spdx_license_url": "https://spdx.org/licenses/CC-BY-ND-3.0.html#licenseText",
+    "spdx_name": "Creative Commons Attribution No Derivatives 3.0",
+    "url": "http://creativecommons.org/licenses/by-nd/3.0/"
+  },
   "Design Science License": {
     "approved": "yes",
     "fedora_abbrev": "DSL",
@@ -5917,6 +6853,39 @@
     "spdx_license_url": "",
     "spdx_name": "",
     "url": "http://www.cacert.org/policy/NRPDisclaimerAndLicence.php"
+  },
+  "Creative Commons Attribution-NonCommercial-NoDerivs": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "Creative Commons Attribution-NonCommercial-NoDerivs",
+    "id": "620",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CC-BY-NC-ND-3.0.txt",
+    "spdx_abbrev": "CC-BY-NC-ND-3.0",
+    "spdx_license_url": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.html#licenseText",
+    "spdx_name": "Creative Commons Attribution Non Commercial No Derivatives 3.0",
+    "url": "http://creativecommons.org/licenses/by-nc-nd/3.0/"
+  },
+  "Creative Commons Attribution-NonCommercial": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "Creative Commons Attribution-NonCommercial",
+    "id": "621",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CC-BY-NC-3.0.txt",
+    "spdx_abbrev": "CC-BY-NC-3.0",
+    "spdx_license_url": "https://spdx.org/licenses/CC-BY-NC-3.0.html#licenseText",
+    "spdx_name": "Creative Commons Attribution Non Commercial 3.0",
+    "url": "http://www.cacert.org/policy/NRPDisclaimerAndLicence.php"
+  },
+  "Creative Commons Attribution-NonCommercial-ShareAlike": {
+    "approved": "no",
+    "fedora_abbrev": "",
+    "fedora_name": "Creative Commons Attribution-NonCommercial-ShareAlike",
+    "id": "622",
+    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/CC-BY-NC-SA-3.0.txt",
+    "spdx_abbrev": "CC-BY-NC-SA-3.0",
+    "spdx_license_url": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.html#licenseText",
+    "spdx_name": "Creative Commons Attribution Non Commercial Share Alike 3.0",
+    "url": "http://creativecommons.org/licenses/by-nc-sa/3.0/"
   },
   "Creative Commons Sampling Plus 1.0": {
     "approved": "no",
@@ -6071,6 +7040,17 @@
     "spdx_name": "",
     "url": "https://fedoraproject.org/wiki/Licensing/HersheyFontLicense"
   },
+  "IPA Font License": {
+    "approved": "yes",
+    "fedora_abbrev": "IPA",
+    "fedora_name": "IPA Font License",
+    "id": "637",
+    "license_text_url": "",
+    "spdx_abbrev": "IPA",
+    "spdx_license_url": "",
+    "spdx_name": "IPA Font License",
+    "url": "https://fedoraproject.org/wiki/Licensing/IPAFontLicense"
+  },
   "Liberation Font License": {
     "approved": "yes",
     "fedora_abbrev": "Liberation",
@@ -6203,4 +7183,5 @@
     "spdx_name": "",
     "url": "https://fedoraproject.org/wiki/Licensing/LiteratFontLicense"
   }
+
 }

--- a/src/test/resources/test_import_url_rh_license.json
+++ b/src/test/resources/test_import_url_rh_license.json
@@ -2606,28 +2606,6 @@
     "spdx_name": "",
     "url": "https://enterprise.dejacode.com/licenses/public/indiana-extreme/?_list_filters=q%3Dindiana%2Bextreme#license-text"
   },
-  "Indiana University Extreme! Lab Software License Version 1.1.1": {
-    "approved": "yes",
-    "fedora_abbrev": "",
-    "fedora_name": "",
-    "id": "584",
-    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Indiana_Extreme_License_1.1.1.txt",
-    "spdx_abbrev": "",
-    "spdx_license_url": "",
-    "spdx_name": "",
-    "url": "https://enterprise.dejacode.com/licenses/public/indiana-extreme/?_list_filters=q%3Dindiana%2Bextreme#license-text"
-  },
-  "indiana-extreme": {
-    "approved": "yes",
-    "fedora_abbrev": "",
-    "fedora_name": "",
-    "id": "585",
-    "license_text_url": "http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/avibelli/licenses/Indiana_Extreme_License_1.1.1.txt",
-    "spdx_abbrev": "",
-    "spdx_license_url": "",
-    "spdx_name": "",
-    "url": "https://enterprise.dejacode.com/licenses/public/indiana-extreme/?_list_filters=q%3Dindiana%2Bextreme#license-text"
-  },
   "Info-ZIP License": {
     "approved": "unknown",
     "fedora_abbrev": "",


### PR DESCRIPTION
Extend RSQL syntax to license, removing the internal cache. 
Improved the import of licenses and alias, code can now remove duplicates.